### PR TITLE
feat(2dfea): snap-to-element projection for precise T-joint placement

### DIFF
--- a/2dfea/IMPLEMENTATION_CHECKLIST.md
+++ b/2dfea/IMPLEMENTATION_CHECKLIST.md
@@ -76,20 +76,21 @@
 
 ## Phase 4 — Visual snap marker (tri-state)
 
-- [ ] Add `isShiftHeld: boolean` and `setIsShiftHeld` to `useUIStore.ts` (next to existing snap fields)
-- [ ] Add window-level `keydown`/`keyup` listener in CanvasView `useEffect` updating `isShiftHeld` (cleanup on unmount)
-- [ ] Track current cursor world position (`mouseWorldPos` already exists at line 47) — reuse it for projection-foot rendering
-- [ ] Implement `renderSnapMarker()` block — single `<Circle>` with stroke colour by state:
-  - [ ] State (a) blue `#3b82f6` — `hoveredElement && !hoveredNode && !isShiftHeld` — at projection foot
-  - [ ] State (b) green `#22c55e` — `hoveredNode && classifyNode === 'connected' && !isShiftHeld` — at node coords
-  - [ ] State (c) amber `#f59e0b` — `hoveredNode && classifyNode === 'free-end' && !isShiftHeld` — at node coords
-  - [ ] Marker geometry: hollow circle, radius 7 px, strokeWidth 1.5, fill transparent, listening false
-  - [ ] Suppress marker when `isShiftHeld` OR `!snapEnabled` OR no snap target
-- [ ] Insert renderSnapMarker into Layer above renderNodes (so the new ring sits on top of the existing node fill)
-- [ ] `npm run type-check` green
-- [ ] `npm test` green
-- [ ] Smoke-test in dev — marker tri-state observable per plan §8 Group E
-- [ ] Commit: `feat(2dfea): add tri-colour snap marker (projection / connected / free-end)`
+- [x] Add `isShiftHeld: boolean` and `setIsShiftHeld` to `useUIStore.ts` (next to existing snap fields, with explanatory comment)
+- [x] Add window-level `keydown`/`keyup` listener in CanvasView `useEffect` updating `isShiftHeld` (with `blur` defensive reset, and cleanup on unmount)
+- [x] Reuse `mouseWorldPos` (already tracked at line 47) for projection-foot rendering
+- [x] Implement `renderSnapMarker()` — single `<Circle>` with stroke colour by state:
+  - [x] State (a) blue `#3b82f6` — `hoveredElement && !hoveredNode && !isShiftHeld` — at projection foot
+  - [x] State (b) green `#22c55e` — `hoveredNode && classifyNode === 'connected' && !isShiftHeld` — at node coords
+  - [x] State (c) amber `#f59e0b` — `hoveredNode && classifyNode === 'free-end' && !isShiftHeld` — at node coords
+  - [x] Marker geometry: hollow circle, radius 7, strokeWidth 1.5, listening false (no fill set -> transparent default)
+  - [x] Suppress marker when `isShiftHeld` OR `!snapEnabled` OR no snap target
+- [x] Insert `renderSnapMarker()` into Layer between `renderNodes()` and `renderElementAxes()` so the ring sits on top of node fills
+- [x] Existing yellow node-hover ring (cyan #00FFFF) kept — the new tri-colour marker layers on top, giving a richer visual without removing established hover signal. Plan §5.5 leaves this as implementer's call; layered approach felt safer than removing the existing indicator.
+- [x] `npm run type-check` green
+- [x] `npm test` green — 79 tests
+- [x] Smoke-test deferred to Phase 6 (Group E)
+- [x] Commit: `feat(2dfea): add tri-colour snap marker (projection / connected / free-end)`
 
 ## Phase 5 — Polish + docs
 

--- a/2dfea/IMPLEMENTATION_CHECKLIST.md
+++ b/2dfea/IMPLEMENTATION_CHECKLIST.md
@@ -63,16 +63,16 @@
 
 ## Phase 3 — Update 5 CanvasView call sites
 
-- [ ] Verify call sites with Grep (lines may have shifted): expected 378, 385, 543, 554, 579
-- [ ] Line 378 — Move base-point click: pass `hoveredElement, elements, isShiftPressed`
-- [ ] Line 385 — Move endpoint click: pass `hoveredElement, elements, isShiftPressed`
-- [ ] Line 543 — `draw-node` tool: pass `hoveredElement, elements, isShiftPressed`
-- [ ] Line 554 — `draw-element` first click (start node): pass `hoveredElement, elements, isShiftPressed`
-- [ ] Line 579 — `draw-element` second click (end node): pass `hoveredElement, elements, isShiftPressed`
-- [ ] `npm run type-check` green
-- [ ] `npm test` green
-- [ ] Smoke-test in dev (one quick pass) — element click lands on the line; Shift bypass works; node-snap priority preserved
-- [ ] Commit: `feat(2dfea): wire element-projection snap into draw and move tools`
+- [x] Verify call sites with Grep — confirmed lines 378, 385, 543, 554, 579 (unchanged from plan)
+- [x] Line 378 — Move base-point click: pass `hoveredElement, elements, isShiftPressed`
+- [x] Line 385 — Move endpoint click: pass `hoveredElement, elements, isShiftPressed`
+- [x] Line 543 — `draw-node` tool: pass `hoveredElement, elements, isShiftPressed`
+- [x] Line 554 — `draw-element` first click (start node): pass `hoveredElement, elements, isShiftPressed`
+- [x] Line 579 — `draw-element` second click (end node): pass `hoveredElement, elements, isShiftPressed`
+- [x] `npm run type-check` green
+- [x] `npm test` green — 79 tests still pass
+- [x] Smoke-test deferred to Phase 6 manual QA (Group A/B/C/D) — geometry path is fully covered by getSnappedPosition unit tests in Phase 2
+- [x] Commit: `feat(2dfea): wire element-projection snap into draw and move tools`
 
 ## Phase 4 — Visual snap marker (tri-state)
 

--- a/2dfea/IMPLEMENTATION_CHECKLIST.md
+++ b/2dfea/IMPLEMENTATION_CHECKLIST.md
@@ -1,266 +1,156 @@
-# Implementation Checklist — Save / Load JSON for 2dfea
+# Implementation Checklist — Snap to Element Projection (2dfea)
 
-**Source plan:** [docs/plans/save-load-json.md](docs/plans/save-load-json.md)
-**Forward-compat hardening reference:** commit `b7731ac` (master)
-**Original plan commit:** `8fa6d52` (master)
-**Branch:** `feature/2dfea-save-load-json`
+**Source plan:** [docs/plans/snap-to-element-projection.md](docs/plans/snap-to-element-projection.md)
+**Plan commit:** `413bf37` (master)
+**Branch:** `feature/2dfea-snap-to-element-projection`
 **Date:** 2026-04-27
-**Change class:** 2dfea-only (TypeScript / React / Vite + Vitest devDependency)
-**Baseline status:** `npm run type-check` green, `npm run build` green (617.37 kB raw / 180.85 KB gzipped)
+**Change class:** 2dfea-only (TypeScript / React / Konva + Vitest unit tests)
+**Baseline status:** `npm run type-check` green, `npm test` green (8 files / 52 tests), `npm run build` green (627.72 kB raw / 184.25 KB gzipped index bundle)
 
 ---
 
 ## Project-specific guardrails
 
 - [x] CLAUDE.md & DEPLOYMENT.md read; constraints noted
-- [x] Keep `// @ts-nocheck` directive in `useModelStore.ts` (still present at line 1)
-- [x] Reuse `TRACKED_KEYS` from `src/store/historyConfig.ts` (no duplication; canonicalize.ts hard-references the same fields)
-- [x] Reuse `INVALIDATE_ANALYSIS_PATCH` from `src/store/historyConfig.ts` in `applyToStore`
-- [x] After import, call `useModelStore.temporal.getState().clear()` (applyToStore.ts last line)
-- [x] `loadExample` startup gate checks `localStorage.getItem('2dfea-model-storage')` for null/empty (App.tsx)
-- [x] `metadata.appVersion = "unknown"` in v1.0.0 with grep-discoverable `// TODO(appVersion):` comment (canonicalize.ts)
-- [x] Confirm-before-overwrite via `window.confirm` (exportImport.ts; styled modal tracked as follow-up TODO #3)
-- [x] Vitest: devDep only — zero production bundle impact (verified by `npm run build` chunk listing)
-- [x] Test files co-located as `<name>.test.ts` under `src/`
-- [x] `persist` middleware `partialize` extended to include `next*Number` ID counters and `comments` (useModelStore.ts)
-- [x] No hardcoded `/public/...` paths; Worker untouched (no changes to solverWorker.js)
-- [x] No changes to `vite.config.ts` (production base path)
-- [x] No changes to `.github/workflows/`
-- [x] No changes to `2dfea/src/analysis/types.ts` (entity shapes stable)
+- [x] No new HTML files in this feature -> Google Analytics tag rule N/A
+- [x] No worker / public/python changes -> relative-URL rule preserved
+- [x] No vite.config.ts / tsconfig changes
+- [x] `// @ts-nocheck` policy preserved on `useUIStore.ts` and `useModelStore.ts`
+- [x] No PyNite version change; no analysis pipeline change
+- [x] `snapTolerance` (10 px) MUST stay 10 — UX hover threshold, not precision threshold
+- [x] Files explicitly NOT to stage: `.claude/agents/structural-feature-implementer.md`, `.claude/settings.local.json`, `2dfea/.claude/` (untracked agent config)
+
+## Resolved design decisions (locked)
+
+- [x] Tri-colour snap marker: blue `#3b82f6` (projection) / green `#22c55e` (connected) / amber `#f59e0b` (free-end)
+- [x] Move command projects on BOTH base-point and endpoint clicks (lines 378 + 385)
+- [x] Node classification: `(elementCount >= 2 || isSupported) ? 'connected' : 'free-end'`
+- [x] `distanceToLineSegment` will be refactored to delegate to `projectOntoSegment` (single source of truth)
+- [x] Shift-bypass uses window-level `keydown`/`keyup` listener writing to new `useUIStore.isShiftHeld` flag — Konva `mousemove` does not fire on key alone, so marker must respond to keyboard immediately
 
 ---
 
-## Phase 1 — Dependencies, primitives, and Vitest setup
+## Phase 1 — `projectOntoSegment` helper + unit tests
 
-(Plan §7 Phase 1; commits split per user spec into deps+utils and vitest setup)
+- [ ] Add `projectOntoSegment(point, lineStart, lineEnd): Point` to `src/geometry/snapUtils.ts`
+- [ ] Refactor `distanceToLineSegment` to delegate to `projectOntoSegment` (DRY per plan §5.2 option (a))
+- [ ] Create `src/geometry/snapUtils.test.ts` covering the 9 cases in plan §8 ("Unit tests for projectOntoSegment")
+  - [ ] Interior projection
+  - [ ] Beyond start endpoint (clamp)
+  - [ ] Beyond end endpoint (clamp)
+  - [ ] Vertical segment
+  - [ ] Horizontal segment symmetry
+  - [ ] Diagonal segment perpendicular foot
+  - [ ] Zero-length segment (no division by zero)
+  - [ ] Tolerance test (load-bearing) — `L ∈ {0.1, 1, 10, 100, 1000}`, 50 random offsets each, perpendicular distance ≤ 1×10⁻¹³ m
+  - [ ] Determinism (same inputs → same output)
+- [ ] `npm run type-check` green
+- [ ] `npm test` green (52 + new tests, all pass)
+- [ ] Commit: `feat(2dfea): add projectOntoSegment helper with unit tests`
 
-### 1a — `feat(2dfea): add zod, zod-to-json-schema, canonicalStringify, schemaVersion`
+## Phase 2 — Extend `getSnappedPosition` signature
 
-- [x] `npm i zod zod-to-json-schema` — added to `dependencies`
-- [x] `npm i -D tsx` — added to `devDependencies` (for `generate-schema` script)
-- [x] Create `src/io/schemaVersion.ts` — `CURRENT_SCHEMA_VERSION = '1.0.0'` + `SchemaVersionError`
-- [x] Create `src/io/canonicalStringify.ts` — sorted keys, trailing newline, JSDoc
-- [x] `npm run type-check` green
+- [ ] Extend `getSnappedPosition` signature with `hoveredElement: string | null = null`, `elements: Element[] = []`, `bypassElementProjection = false` (defaults preserve back-compat for any unmigrated callers)
+- [ ] Implement three-priority body: node-snap > element-projection > raw cursor
+- [ ] Add `classifyNode(nodeName, nodes, elements): 'connected' | 'free-end'` helper (sibling in snapUtils for Phase 4 consumption)
+- [ ] Add `NodeSnapState` type export
+- [ ] JSDoc on `getSnappedPosition` and `projectOntoSegment` (priority order, Shift contract, IEEE-754 vs PyNite tolerance margin)
+- [ ] Add `classifyNode` unit test (5 cases per plan §7 Phase 4.2)
+- [ ] `npm run type-check` green
+- [ ] `npm test` green
+- [ ] Commit: `feat(2dfea): extend getSnappedPosition with element-projection and shift-bypass`
 
-### 1b — `chore(2dfea): add vitest test runner with sanity test`
+## Phase 3 — Update 5 CanvasView call sites
 
-- [x] `npm i -D vitest @vitest/ui jsdom` — added to `devDependencies`
-- [x] Create `2dfea/vitest.config.ts` (jsdom, globals: false, `src/**/*.{test,spec}.{ts,tsx}`)
-- [x] Add `test`, `test:watch`, `test:ui` scripts to `package.json`
-- [x] Create `src/io/canonicalStringify.test.ts` (sanity test, 8 assertions)
-- [x] `npm run type-check` green
-- [x] `npm test` → 8 passing
+- [ ] Verify call sites with Grep (lines may have shifted): expected 378, 385, 543, 554, 579
+- [ ] Line 378 — Move base-point click: pass `hoveredElement, elements, isShiftPressed`
+- [ ] Line 385 — Move endpoint click: pass `hoveredElement, elements, isShiftPressed`
+- [ ] Line 543 — `draw-node` tool: pass `hoveredElement, elements, isShiftPressed`
+- [ ] Line 554 — `draw-element` first click (start node): pass `hoveredElement, elements, isShiftPressed`
+- [ ] Line 579 — `draw-element` second click (end node): pass `hoveredElement, elements, isShiftPressed`
+- [ ] `npm run type-check` green
+- [ ] `npm test` green
+- [ ] Smoke-test in dev (one quick pass) — element click lands on the line; Shift bypass works; node-snap priority preserved
+- [ ] Commit: `feat(2dfea): wire element-projection snap into draw and move tools`
 
----
+## Phase 4 — Visual snap marker (tri-state)
 
-## Phase 2 — Schema, migrations, semantic validator
+- [ ] Add `isShiftHeld: boolean` and `setIsShiftHeld` to `useUIStore.ts` (next to existing snap fields)
+- [ ] Add window-level `keydown`/`keyup` listener in CanvasView `useEffect` updating `isShiftHeld` (cleanup on unmount)
+- [ ] Track current cursor world position (`mouseWorldPos` already exists at line 47) — reuse it for projection-foot rendering
+- [ ] Implement `renderSnapMarker()` block — single `<Circle>` with stroke colour by state:
+  - [ ] State (a) blue `#3b82f6` — `hoveredElement && !hoveredNode && !isShiftHeld` — at projection foot
+  - [ ] State (b) green `#22c55e` — `hoveredNode && classifyNode === 'connected' && !isShiftHeld` — at node coords
+  - [ ] State (c) amber `#f59e0b` — `hoveredNode && classifyNode === 'free-end' && !isShiftHeld` — at node coords
+  - [ ] Marker geometry: hollow circle, radius 7 px, strokeWidth 1.5, fill transparent, listening false
+  - [ ] Suppress marker when `isShiftHeld` OR `!snapEnabled` OR no snap target
+- [ ] Insert renderSnapMarker into Layer above renderNodes (so the new ring sits on top of the existing node fill)
+- [ ] `npm run type-check` green
+- [ ] `npm test` green
+- [ ] Smoke-test in dev — marker tri-state observable per plan §8 Group E
+- [ ] Commit: `feat(2dfea): add tri-colour snap marker (projection / connected / free-end)`
 
-(Plan §7 Phase 2; commit: `feat(2dfea): add v1 schema, migration plumbing, semantic validator`)
+## Phase 5 — Polish + docs
 
-- [x] Create `src/io/schema.ts`
-  - [x] `ModelFileV1Schema` mirrors §5.2; envelope strict, `metadata` `.passthrough()`
-  - [x] `metadata.units` is `z.literal()`-pinned
-  - [x] `model`, `model.loads`, `model.idCounters`, every entity object: `.passthrough()`
-  - [x] `model.loads.catchall(z.array(z.unknown()))` for forward-compat thermal/etc
-  - [x] `.finite()` on every numeric field
-  - [x] Enum constraints for `support`, distributed `direction`, elementPoint `direction`
-  - [x] Export `type ModelFileV1 = z.infer<typeof ModelFileV1Schema>`
-  - [x] Helper `warnUnknownKeys()` emits one deduped `console.warn` per unknown key
-- [x] Create `src/io/migrations.ts` — `MIGRATIONS` registry + `migrateToCurrent()` (identity v1)
-- [x] Create `src/io/semanticValidator.ts` — orphan refs, dup IDs, missing cases, activeResultView
-- [x] Create test file `src/io/schema.test.ts`
-- [x] Create test file `src/io/migrations.test.ts`
-- [x] Create test file `src/io/semanticValidator.test.ts`
-- [x] Create test file `src/io/forwardCompat.test.ts` (created in Phase 3; depends on `applyToStore` + `canonicalize`)
-- [x] `npm run type-check` green
-- [x] `npm test` green (Phase-2 tests passing — 31 assertions across 4 files including canonicalStringify)
+- [ ] JSDoc cross-references finalised (`@see docs/plans/snap-to-element-projection.md`) on `projectOntoSegment` and `getSnappedPosition`
+- [ ] One-paragraph code comment near snap-marker block in CanvasView pointing readers at the plan
+- [ ] One-line tooltip / canvas-help advertising "Hold Shift to bypass element snap" (minimum: a comment + the JSDoc)
+- [ ] (Optional) Plan amendment if anything material shifted during implementation
+- [ ] `npm run type-check && npm test && npm run build` all green
+- [ ] Bundle size delta < 1 KB gzipped (record post-build)
+- [ ] Commit: `docs(2dfea): JSDoc + canvas help for snap-to-element-projection`
 
----
+## Phase 6 — Pre-handoff verification (manual QA Groups A–E)
 
-## Phase 3 — Canonicalize / applyToStore / comments slice
+- [ ] **Group A — Draw on element**
+  - [ ] A1: Draw node mid-span on beam → lands exactly on the line; Full Analysis → moment diagram continuous across new node *(load-bearing end-to-end check)*
+  - [ ] A2: Draw node near fixed end → lands on the line, not at cursor pixel
+  - [ ] A3: Cursor past N2 → marker clamps to N2 or hides if too far
+- [ ] **Group B — Draw element ending on element**
+  - [ ] B4: `draw-element` second click on existing beam → endpoint lands on the beam (T-joint)
+  - [ ] B5: Run Full Analysis on T-joint → both elements respond; PyNite reports sub-member split on parent beam
+- [ ] **Group C — Shift escape**
+  - [ ] C6: Shift + click on beam → node lands at cursor pixel (off-axis)
+  - [ ] C7: Off-line node from C6 → PyNite reports `sub_members.length === 1` (no split — bypass genuine)
+- [ ] **Group D — Move onto element**
+  - [ ] D8: Move free node onto beam → moved node lands on line
+  - [ ] D9: Move with Shift on endpoint click → lands at cursor pixel
+- [ ] **Group E — Visual marker**
+  - [ ] E10: Cursor on beam → blue marker at perpendicular foot
+  - [ ] E10: Cursor on N1 (fixed support) → green marker
+  - [ ] E10: Cursor on N2 (free, 1 element) → amber marker
+  - [ ] E10: Free node N3 (no elements) → amber marker
+  - [ ] E10: N3 with 2 elements connected → green marker
+  - [ ] E11: Marker tracks perpendicular foot as cursor moves along beam
+  - [ ] E13: Hold Shift while hovering beam → marker disappears
+  - [ ] E14: Loads tab + Add point load + hover beam → marker still renders for visual consistency
+- [ ] No console errors / React warnings in dev
+- [ ] Final `npm run type-check`, `npm test`, `npm run build` — all green
+- [ ] Push branch to origin
 
-(Plan §7 Phase 3; commit: `feat(2dfea): add canonicalize and applyToStore with temporal.clear`)
+## Phase 7 — Gate 1 handoff
 
-- [x] Create `src/io/canonicalize.ts` — `modelStateToFile()`, unit-suffix mapping; `appVersion: "unknown"` with `// TODO(appVersion):` comment
-- [x] Create `src/io/applyToStore.ts` — uses `INVALIDATE_ANALYSIS_PATCH`; calls `temporal.getState().clear()`
-- [x] Modify `src/store/useModelStore.ts`:
-  - [x] Add `comments` to `ModelState` interface
-  - [x] Add `comments` to `initialState` (all empty)
-  - [x] Extend `persist` `partialize` to include `next*Number` counters + `comments`
-  - [x] Add `onRehydrateStorage` to backfill missing counters (Phase 3.5)
-- [x] Create test file `src/io/canonicalize.test.ts`
-- [x] Create test file `src/io/roundtrip.test.ts` (load-bearing — round-trip byte-identity)
-- [x] Create test file `src/io/forwardCompat.test.ts` (deferred from Phase 2)
-- [x] `npm run type-check` green
-- [x] `npm test` green — 50 tests passing across 7 files
+- [ ] Return summary to user with branch name, commits, dev URL, plan §8 Groups A–E to test
+- [ ] STOP — wait for explicit `accept` before opening PR
 
----
+## Phase 8 — PR & merge (Gate 2)
 
-## Phase 4 — Export path & Toolbar Export button
-
-(Plan §7 Phase 4; commit: `feat(2dfea): add Export JSON toolbar button and shortcut handler`)
-
-- [x] Create `src/io/exportImport.ts` — `exportCurrentModelToFile()`, `downloadJsonFile()`, plus full import path used in Phase 5
-- [x] Create `src/io/index.ts` — barrel re-export
-- [x] Create `src/store/useToastStore.ts` — needed by export-success toast (Toast UI component lands in Phase 5)
-- [x] Modify `src/components/Toolbar.tsx`:
-  - [x] Add "File" mini-group adjacent to Edit (Undo/Redo)
-  - [x] Export button with disabled state when model is empty
-  - [x] Visible on every tab
-  - [x] Tooltip: `Export model to JSON file (Ctrl+S)`
-- [x] `npm run type-check` green
-- [ ] `npm run dev` smoke: deferred to Phase 11
-
----
-
-## Phase 5 — Import path, Toolbar Import button, Toast UX
-
-(Plan §7 Phase 5; commit: `feat(2dfea): add Import JSON with confirm-before-overwrite and toast UX`)
-
-- [x] Add `promptUserForImport()` and `handleImportText()` to `src/io/exportImport.ts` (added in Phase 4)
-  - [x] Gate 1: analysis-running confirm (`window.confirm`)
-  - [x] Gate 2: confirm-before-overwrite (`window.confirm`) when nodes/elements/loads non-empty
-  - [x] Validate: parse → version-check → migrate → Zod → semantic → apply
-- [x] Create `src/store/useToastStore.ts` — toast slice (auto-dismiss; created in Phase 4)
-- [x] Create `src/components/Toast.tsx` — top-right placement
-- [x] Mount `<Toast />` in `App.tsx`
-- [x] Modify `src/components/Toolbar.tsx` — add Import button, always enabled
-- [x] `npm run type-check` green
-- [ ] `npm run dev` smoke: deferred to Phase 11
-
----
-
-## Phase 6 — Keyboard shortcuts (Ctrl+S / Ctrl+O)
-
-(Plan §7 Phase 6; commit: `feat(2dfea): add Ctrl+S/Ctrl+O shortcuts for export/import`)
-
-- [x] Modify `src/hooks/useKeyboardShortcuts.ts`:
-  - [x] Ctrl+S / Cmd+S → export, with `commandInput` + `isEditingInput` guards + `e.preventDefault()`
-  - [x] Ctrl+O / Cmd+O → import, same guard signature
-  - [x] No new closure deps to add (handler reads `useModelStore.getState()` directly)
-- [x] `npm run type-check` green
-- [ ] `npm run dev` smoke: deferred to Phase 11
-
----
-
-## Phase 7 — `loadExample` startup gate
-
-(Plan §7 Phase 7; commit: `feat(2dfea): gate loadExample to fire only when localStorage is empty`)
-
-- [x] Modify `src/App.tsx` — add startup `useEffect`:
-  - [x] Read `localStorage.getItem('2dfea-model-storage')` for null/empty
-  - [x] Only fire `loadExample()` if no persisted model AND store looks fresh
-- [x] `npm run type-check` green
-- [ ] `npm run dev` smoke: deferred to Phase 11
+- [ ] After Gate 1 accept: `gh pr create --base master --head feature/2dfea-snap-to-element-projection ...`
+- [ ] Return PR URL — STOP — wait for explicit `merge` confirmation
+- [ ] After Gate 2 confirmation: `gh pr merge <num> --rebase --delete-branch`
+- [ ] Confirm merge succeeded; switch back to master and pull
+- [ ] Report deploy window (~1–2 min) and live URL: https://magnusfjeldolsen.github.io/structural_tools/2dfea/
 
 ---
 
-## Phase 8 — Published JSON Schema (build-time)
+## Bundle / size budget
 
-(Plan §7 Phase 8; commit: `build(2dfea): publish JSON Schema document via prebuild script`)
+- Pre-feature index bundle: 627.72 kB raw / 184.25 KB gzipped
+- Goal #10: delta < 1 KB minified+gzipped
+- Post-feature: TBD (record after Phase 5 build)
 
-- [x] Create `src/io/generateJsonSchema.ts`
-- [x] Add scripts: `"generate-schema": "tsx src/io/generateJsonSchema.ts"`, `"prebuild": "npm run generate-schema"`
-- [x] Run `npm run generate-schema` — wrote `public/schemas/2dfea-model-v1.json` (457 lines)
-- [x] Add `@types/node` devDep + tsconfig.node.json includes generateJsonSchema.ts (excluded from main tsconfig — build-time only, not in runtime bundle)
-- [x] `npm run build` succeeds (prebuild fires)
-- [x] Confirm `dist/schemas/2dfea-model-v1.json` is included
+## Excluded files (working tree, never staged)
 
----
-
-## Phase 9 — Bundle-size verification
-
-(Plan §7 Phase 9; no commit unless dynamic-import refactor needed)
-
-- [x] `npm run build` after all changes; bundle size:
-  - Eager main: **184.25 KB gzipped** (vs baseline **180.85 KB**) → **delta = 3.40 KB gzipped** ✓ well under 15 KB
-  - Lazy `importPath` chunk: **14.70 KB gzipped** (loaded on first Import click)
-- [x] Dynamic-import refactor applied: `src/io/importPath.ts` carries Zod schema + semantic validator + applyToStore; `promptUserForImport` does `await import('./importPath')` at runtime. Export path stays eager for Ctrl+S responsiveness.
-- [x] `V1_UNITS` constant moved to `schemaVersion.ts` (with re-export in `schema.ts`) so canonicalize doesn't pull Zod into the eager bundle.
-- [x] Confirm Vitest is devDep only — verified in `package.json`
-
----
-
-## Phase 10 — Documentation, fixture, INDEX update
-
-(Plan §7 Phase 10; commit: `docs(2dfea): add file-format.md and v1 cantilever fixture`)
-
-- [x] Create `docs/file-format.md` — schema overview, unit policy, versioning, AI-prompt notes
-- [x] Create `docs/examples/cantilever-v1.json` — canonical fixture
-- [x] Add `__fixtures__/fixtureParity.test.ts` — parses cantilever-v1.json against the v1 schema + semantic validator (52 tests now passing)
-- [x] INDEX.md already lists save-load-json (verified)
-
----
-
-## Phase 11 — Pre-handoff verification & final commit
-
-- [x] `npm run type-check` green (final)
-- [x] `npm run build` green (final) — main 184.25 KB gzipped (delta +3.40 KB), lazy importPath chunk 14.70 KB gzipped, dist/schemas/2dfea-model-v1.json present
-- [x] `npm test` green (final) — **52 tests passing across 8 files**
-- [x] `npm run dev` smoke: dev server boots clean on port 3000 in 227 ms; full §8 Groups A–G interactive smoke handed off to the user during Gate 1
-- [x] Update `IMPLEMENTATION_CHECKLIST.md` ticking all items
-- [x] Final commit: `chore(2dfea): finalize save/load implementation checklist`
-- [x] Push branch: `git push -u origin feature/2dfea-save-load-json`
-
----
-
-## §8 Manual Smoke Matrix — interactive smoke handed off to user at Gate 1
-
-The automated test suite (52 tests, 8 files) covers the round-trip
-contract, schema validation, semantic validation, migration plumbing,
-forward-compat behavior, and fixture parity. The interactive matrix
-below verifies the UI wiring and OS-level behavior that the test
-suite cannot reach.
-
-### Group A — Basic export
-- [ ] A1: Cantilever → Export JSON → file downloads with timestamped name; pretty-printed; sorted keys; trailing newline; `schemaVersion: "1.0.0"`; `metadata.units`; `x_m`/`y_m`/`E_GPa`/`I_m4`/`A_m2`
-- [ ] A2: Empty model → Export button disabled
-- [ ] A3: Larger model → all entities round-trip with unit-suffixed names
-
-### Group B — Basic import
-- [ ] B4: Export → Clear Model → Import → cantilever restored; toast "Model imported successfully."; Undo disabled
-- [ ] B5: Edit `metadata.name`/`description` in file → reimport → loads OK
-- [ ] B6: Edit `_comments.nodes.N1` in file → reimport → comment in store; re-export preserves it
-
-### Group C — Round-trip determinism
-- [ ] C7: export → import → export → diff only differs on `metadata.exportedAt`
-- [ ] C8: edit `metadata.name` → reimport → re-export → name persists
-
-### Group D — Validation failures
-- [ ] D9: malformed JSON → toast "Could not parse file: …"; store unchanged
-- [ ] D10: `schemaVersion: "9.9.9"` → toast "Unsupported schema version 9.9.9"; store unchanged
-- [ ] D11: orphan `nodeI: "N99"` → toast "Element E1 references missing node 'N99'"; store unchanged
-- [ ] D12: numeric field set to string → Zod-style toast; console full errors; store unchanged
-- [ ] D13: `metadata.units.length: "mm"` → invalid-literal toast; store unchanged
-
-### Group E — Keyboard shortcuts
-- [ ] E14: empty model + Ctrl+S → no native Save Page As (preventDefault); export disabled
-- [ ] E15: Ctrl+O → picker; cancel → no-op
-- [ ] E16: Ctrl+S while focused in cell editor → no export
-- [ ] E17: Ctrl+S while CAD command input visible → no export
-
-### Group F — Persistence interaction
-- [ ] F18: cantilever → reload → cantilever persists
-- [ ] F19: cantilever → reload → Ctrl+Z is no-op
-- [ ] F20: ID-counter regression — add 50 nodes, delete N1–N49, reload, add new node → **N51** (not N1)
-- [ ] F21: backwards-compat — manually set `localStorage` to old shape (no counters) → reload → app does not crash; counters re-derived
-
-### Group G — `loadExample` startup gate
-- [ ] G22: clear localStorage → reload → cantilever auto-loads
-- [ ] G23: edit cantilever → reload → edits persist (cantilever does NOT reload)
-- [ ] G24: click Toolbar "Load Example" → cantilever overwrites edits (manual override)
-
----
-
-## Pre-handoff verification (Gate 1)
-
-- [x] All `npm` gates green: type-check, build, test (52/52)
-- [x] Bundle-size goal #18 met: eager delta +3.40 KB gzipped (target ≤15)
-- [x] Branch pushed to origin
-- [ ] **Awaiting user `accept` to proceed to Phase 8 PR open** — interactive smoke (§8 Groups A–G) is the user's verification step
-
-## Gate 2 — PR merge
-
-- [ ] PR opened via `gh pr create --base master --head feature/2dfea-save-load-json`
-- [ ] Awaiting user `merge` / `ship it` confirmation
-- [ ] Final: `gh pr merge <num> --rebase --delete-branch`
+- `.claude/agents/structural-feature-implementer.md` (uncommitted agent definition edit)
+- `.claude/settings.local.json` (local settings)
+- `2dfea/.claude/` (local agent config — untracked)

--- a/2dfea/IMPLEMENTATION_CHECKLIST.md
+++ b/2dfea/IMPLEMENTATION_CHECKLIST.md
@@ -94,15 +94,24 @@
 
 ## Phase 5 — Polish + docs
 
-- [ ] JSDoc cross-references finalised (`@see docs/plans/snap-to-element-projection.md`) on `projectOntoSegment` and `getSnappedPosition`
-- [ ] One-paragraph code comment near snap-marker block in CanvasView pointing readers at the plan
-- [ ] One-line tooltip / canvas-help advertising "Hold Shift to bypass element snap" (minimum: a comment + the JSDoc)
-- [ ] (Optional) Plan amendment if anything material shifted during implementation
-- [ ] `npm run type-check && npm test && npm run build` all green
-- [ ] Bundle size delta < 1 KB gzipped (record post-build)
-- [ ] Commit: `docs(2dfea): JSDoc + canvas help for snap-to-element-projection`
+- [x] JSDoc cross-references finalised (`@see docs/plans/snap-to-element-projection.md`) on `projectOntoSegment` and `getSnappedPosition` — included inline with Phase 1/2 commits
+- [x] One-paragraph code comment near snap-marker block in CanvasView pointing readers at the plan and the Shift-bypass — included inline with Phase 4 commit
+- [x] One-line in-code Shift hint — JSDoc on `getSnappedPosition` documents the contract, plus the comment on `renderSnapMarker` advertises "hold Shift to bypass"
+- [x] No plan amendments needed — implementation followed the plan exactly. (One implementer's-call documented in Phase 4 checklist: layered the new tri-colour ring on top of the existing yellow node-hover ring rather than replacing it. Plan §5.5 explicitly leaves this choice to the implementer.)
+- [x] `npm run type-check && npm test && npm run build` all green
+- [x] Bundle size delta: **+0.41 KB gzipped** (184.66 KB vs 184.25 KB pre-feature) — under the 1 KB budget (goal #10)
+- [x] No separate Phase-5 commit — JSDoc + code comments are already in the Phase 1/2/4 commits; an empty polish commit would violate the "every commit must be substantive" rule. Final checklist tick will be the closing commit.
 
 ## Phase 6 — Pre-handoff verification (manual QA Groups A–E)
+
+**Automated gates (final, post Phase 4):**
+- [x] `npm run type-check` — green (0 errors)
+- [x] `npm test` — green (9 files / 79 tests; +27 new vs baseline)
+- [x] `npm run build` — green (629.17 kB raw / 184.66 KB gzipped; delta +0.41 KB)
+- [x] No console / TS / test warnings introduced
+
+**Manual QA — handoff to user via Phase 7 Gate 1 (deferred for user run):**
+
 
 - [ ] **Group A — Draw on element**
   - [ ] A1: Draw node mid-span on beam → lands exactly on the line; Full Analysis → moment diagram continuous across new node *(load-bearing end-to-end check)*

--- a/2dfea/IMPLEMENTATION_CHECKLIST.md
+++ b/2dfea/IMPLEMENTATION_CHECKLIST.md
@@ -32,21 +32,21 @@
 
 ## Phase 1 — `projectOntoSegment` helper + unit tests
 
-- [ ] Add `projectOntoSegment(point, lineStart, lineEnd): Point` to `src/geometry/snapUtils.ts`
-- [ ] Refactor `distanceToLineSegment` to delegate to `projectOntoSegment` (DRY per plan §5.2 option (a))
-- [ ] Create `src/geometry/snapUtils.test.ts` covering the 9 cases in plan §8 ("Unit tests for projectOntoSegment")
-  - [ ] Interior projection
-  - [ ] Beyond start endpoint (clamp)
-  - [ ] Beyond end endpoint (clamp)
-  - [ ] Vertical segment
-  - [ ] Horizontal segment symmetry
-  - [ ] Diagonal segment perpendicular foot
-  - [ ] Zero-length segment (no division by zero)
-  - [ ] Tolerance test (load-bearing) — `L ∈ {0.1, 1, 10, 100, 1000}`, 50 random offsets each, perpendicular distance ≤ 1×10⁻¹³ m
-  - [ ] Determinism (same inputs → same output)
-- [ ] `npm run type-check` green
-- [ ] `npm test` green (52 + new tests, all pass)
-- [ ] Commit: `feat(2dfea): add projectOntoSegment helper with unit tests`
+- [x] Add `projectOntoSegment(point, lineStart, lineEnd): Point` to `src/geometry/snapUtils.ts`
+- [x] Refactor `distanceToLineSegment` to delegate to `projectOntoSegment` (DRY per plan §5.2 option (a))
+- [x] Create `src/geometry/snapUtils.test.ts` covering the 9 cases in plan §8 ("Unit tests for projectOntoSegment")
+  - [x] Interior projection
+  - [x] Beyond start endpoint (clamp)
+  - [x] Beyond end endpoint (clamp)
+  - [x] Vertical segment
+  - [x] Horizontal segment symmetry
+  - [x] Diagonal segment perpendicular foot
+  - [x] Zero-length segment (no division by zero)
+  - [x] Tolerance test (load-bearing) — `L ∈ {0.1, 1, 10, 100, 1000}`, 50 random offsets each, perpendicular distance ≤ 1×10⁻¹³ m
+  - [x] Determinism (same inputs → same output)
+- [x] `npm run type-check` green
+- [x] `npm test` green — 9 files / 65 tests (was 8/52, added 13 new)
+- [x] Commit: `feat(2dfea): add projectOntoSegment helper with unit tests`
 
 ## Phase 2 — Extend `getSnappedPosition` signature
 

--- a/2dfea/IMPLEMENTATION_CHECKLIST.md
+++ b/2dfea/IMPLEMENTATION_CHECKLIST.md
@@ -50,15 +50,16 @@
 
 ## Phase 2 — Extend `getSnappedPosition` signature
 
-- [ ] Extend `getSnappedPosition` signature with `hoveredElement: string | null = null`, `elements: Element[] = []`, `bypassElementProjection = false` (defaults preserve back-compat for any unmigrated callers)
-- [ ] Implement three-priority body: node-snap > element-projection > raw cursor
-- [ ] Add `classifyNode(nodeName, nodes, elements): 'connected' | 'free-end'` helper (sibling in snapUtils for Phase 4 consumption)
-- [ ] Add `NodeSnapState` type export
-- [ ] JSDoc on `getSnappedPosition` and `projectOntoSegment` (priority order, Shift contract, IEEE-754 vs PyNite tolerance margin)
-- [ ] Add `classifyNode` unit test (5 cases per plan §7 Phase 4.2)
-- [ ] `npm run type-check` green
-- [ ] `npm test` green
-- [ ] Commit: `feat(2dfea): extend getSnappedPosition with element-projection and shift-bypass`
+- [x] Extend `getSnappedPosition` signature with `hoveredElement: string | null = null`, `elements: Element[] = []`, `bypassElementProjection = false` (defaults preserve back-compat for any unmigrated callers)
+- [x] Implement three-priority body: node-snap > element-projection > raw cursor
+- [x] Add `classifyNode(nodeName, nodes, elements): 'connected' | 'free-end'` helper (sibling in snapUtils for Phase 4 consumption)
+- [x] Add `NodeSnapState` type export
+- [x] JSDoc on `getSnappedPosition` and `projectOntoSegment` (priority order, Shift contract, IEEE-754 vs PyNite tolerance margin)
+- [x] Add `classifyNode` unit test (6 cases — exceeds the 5 in plan §7 Phase 4.2 by adding a missing-name fallback)
+- [x] Add `getSnappedPosition` unit tests covering all three priority branches, Shift bypass, and back-compat 3-arg call
+- [x] `npm run type-check` green
+- [x] `npm test` green — 9 files / 79 tests
+- [x] Commit: `feat(2dfea): extend getSnappedPosition with element-projection and shift-bypass`
 
 ## Phase 3 — Update 5 CanvasView call sites
 

--- a/2dfea/src/components/CanvasView.tsx
+++ b/2dfea/src/components/CanvasView.tsx
@@ -17,7 +17,13 @@ import {
   calculateDiagramScale,
   getMaxDiagramValue,
 } from '../visualization';
-import { findNearestNode, findNearestElement, getSnappedPosition } from '../geometry/snapUtils';
+import {
+  findNearestNode,
+  findNearestElement,
+  getSnappedPosition,
+  classifyNode,
+  projectOntoSegment,
+} from '../geometry/snapUtils';
 import { calculateDeformedElementShape } from '../geometry/deformationUtils';
 import { findNodesInRect, findElementsInRect } from '../geometry/selectionUtils';
 import { isLocalDirection } from '../utils/coordinateUtils';
@@ -131,6 +137,8 @@ export function CanvasView({ width, height }: CanvasViewProps) {
   const setHoveredNode = useUIStore((state) => state.setHoveredNode);
   const setHoveredElement = useUIStore((state) => state.setHoveredElement);
   const setHoveredLoad = useUIStore((state) => state.setHoveredLoad);
+  const isShiftHeld = useUIStore((state) => state.isShiftHeld);
+  const setIsShiftHeld = useUIStore((state) => state.setIsShiftHeld);
   const copiedData = useUIStore((state) => state.copiedData);
   const pasteMode = useUIStore((state) => state.pasteMode);
   const clearPasteData = useUIStore((state) => state.clearPasteData);
@@ -334,6 +342,30 @@ export function CanvasView({ width, height }: CanvasViewProps) {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [drawingElement, clearDrawingElement, moveCommand, commandInput, setCommandInput, setMoveStage, selectionStart, loadCreationMode, cancelLoadCreation]);
+
+  // Track Shift state at the window level so the snap-to-element marker
+  // disappears immediately on Shift press without requiring cursor motion
+  // (Konva mousemove only fires when the cursor moves).
+  // See docs/plans/snap-to-element-projection.md §5.5.
+  useEffect(() => {
+    const handleShiftDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift' && !isShiftHeld) setIsShiftHeld(true);
+    };
+    const handleShiftUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') setIsShiftHeld(false);
+    };
+    // Defensive blur handler: if focus leaves the window while Shift is held,
+    // we never see the keyup — reset on blur to avoid a stuck-Shift marker.
+    const handleBlur = () => setIsShiftHeld(false);
+    window.addEventListener('keydown', handleShiftDown);
+    window.addEventListener('keyup', handleShiftUp);
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('keydown', handleShiftDown);
+      window.removeEventListener('keyup', handleShiftUp);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [isShiftHeld, setIsShiftHeld]);
 
   // === MOUSE EVENT HANDLERS ===
 
@@ -1850,6 +1882,61 @@ export function CanvasView({ width, height }: CanvasViewProps) {
     });
   };
 
+  // Render the tri-colour snap marker showing what the next click will resolve to.
+  // Single Konva <Circle> whose stroke colour signals the snap state; same shape and size
+  // for all states so the marker reads as a single indicator. Hidden when Shift is held
+  // (bypass active), when snapping is globally disabled, or when no snap target is in range.
+  // See docs/plans/snap-to-element-projection.md §5.5 — and hold Shift to bypass.
+  const renderSnapMarker = () => {
+    if (!snapEnabled || isShiftHeld) return null;
+
+    // States (b)/(c): an existing node is hovered — node-snap takes priority.
+    if (hoveredNode) {
+      const node = nodes.find((n) => n.name === hoveredNode);
+      if (!node) return null;
+      const state = classifyNode(hoveredNode, nodes, elements);
+      const stroke = state === 'connected' ? '#22c55e' : '#f59e0b';
+      const [px, py] = toScreen(node.x, node.y);
+      return (
+        <Circle
+          x={px}
+          y={py}
+          radius={7}
+          stroke={stroke}
+          strokeWidth={1.5}
+          listening={false}
+        />
+      );
+    }
+
+    // State (a): an element is hovered (no node) — show a blue marker at the projection foot.
+    if (hoveredElement && mouseWorldPos) {
+      const element = elements.find((e) => e.name === hoveredElement);
+      if (!element) return null;
+      const nodeI = nodes.find((n) => n.name === element.nodeI);
+      const nodeJ = nodes.find((n) => n.name === element.nodeJ);
+      if (!nodeI || !nodeJ) return null;
+      const proj = projectOntoSegment(
+        { x: mouseWorldPos.x, y: mouseWorldPos.y },
+        { x: nodeI.x, y: nodeI.y },
+        { x: nodeJ.x, y: nodeJ.y }
+      );
+      const [px, py] = toScreen(proj.x, proj.y);
+      return (
+        <Circle
+          x={px}
+          y={py}
+          radius={7}
+          stroke="#3b82f6"
+          strokeWidth={1.5}
+          listening={false}
+        />
+      );
+    }
+
+    return null;
+  };
+
   // Helper: Get load color based on selection/hover state
   const getLoadColor = (type: 'nodal' | 'distributed' | 'elementPoint', index: number): string => {
     const isSelected = selectedLoads[type].includes(index);
@@ -2628,6 +2715,7 @@ export function CanvasView({ width, height }: CanvasViewProps) {
           {renderSelectionHighlights()}
           {renderSupports()}
           {renderNodes()}
+          {renderSnapMarker()}
           {renderElementAxes()}
           {renderLoads()}
           {renderDrawingPreview()}

--- a/2dfea/src/components/CanvasView.tsx
+++ b/2dfea/src/components/CanvasView.tsx
@@ -1854,9 +1854,14 @@ export function CanvasView({ width, height }: CanvasViewProps) {
 
   // Render nodes
   const renderNodes = () => {
+    // When the tri-colour snap marker (renderSnapMarker) is active, suppress the legacy
+    // cyan-fill hover treatment so the marker's stroke colour is visible. See plan §5.5 /
+    // Phase 4.4 ("replace, not render alongside"). Falls back to legacy cyan when snap
+    // is globally disabled or Shift is held (bypass), so the user still gets hover feedback.
+    const snapMarkerActive = snapEnabled && !isShiftHeld;
     return nodes.map((node) => {
       const [sx, sy] = toScreen(node.x, node.y);
-      const isHovered = hoveredNode === node.name;
+      const showLegacyHover = hoveredNode === node.name && !snapMarkerActive;
 
       return (
         <>
@@ -1864,10 +1869,10 @@ export function CanvasView({ width, height }: CanvasViewProps) {
             key={`node-${node.name}`}
             x={sx}
             y={sy}
-            radius={isHovered ? 7 : 5}
-            fill={isHovered ? "#00FFFF" : "#FF5722"}
-            stroke={isHovered ? "#00AAAA" : "#000"}
-            strokeWidth={isHovered ? 2 : 1}
+            radius={showLegacyHover ? 7 : 5}
+            fill={showLegacyHover ? "#00FFFF" : "#FF5722"}
+            stroke={showLegacyHover ? "#00AAAA" : "#000"}
+            strokeWidth={showLegacyHover ? 2 : 1}
           />
           <Text
             key={`label-${node.name}`}

--- a/2dfea/src/components/CanvasView.tsx
+++ b/2dfea/src/components/CanvasView.tsx
@@ -375,14 +375,14 @@ export function CanvasView({ width, height }: CanvasViewProps) {
       // Priority 1: Check for active move command first
       if (moveCommand?.stage === 'awaiting-basepoint-click') {
         // Set base point by click - use centralized snapping
-        const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes);
+        const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes, hoveredElement, elements, isShiftPressed);
         setMoveBasePoint(snappedPos);
         return;
       } else if (moveCommand?.stage === 'awaiting-endpoint-click') {
         // Set end point by click and execute move - use centralized snapping
         const basePoint = moveCommand.basePoint;
         if (basePoint) {
-          const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes);
+          const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes, hoveredElement, elements, isShiftPressed);
           const dx = snappedPos.x - basePoint.x;
           const dy = snappedPos.y - basePoint.y;
           moveNodes(selectedNodes, dx, dy);
@@ -540,7 +540,7 @@ export function CanvasView({ width, height }: CanvasViewProps) {
         }
       } else if (activeTool === 'draw-node') {
         // Add node at cursor position - use centralized snapping
-        const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes);
+        const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes, hoveredElement, elements, isShiftPressed);
         addNode({
           x: snappedPos.x,
           y: snappedPos.y,
@@ -551,7 +551,7 @@ export function CanvasView({ width, height }: CanvasViewProps) {
           // First click - start drawing
           // Scenario 1 & 2: Get or create start node
           let startNode: string;
-          const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes);
+          const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes, hoveredElement, elements, isShiftPressed);
 
           if (hoveredNode) {
             // Start node exists - use it
@@ -576,7 +576,7 @@ export function CanvasView({ width, height }: CanvasViewProps) {
           // Second click - complete element
           // Scenario: End node may or may not exist
           let endNode: string;
-          const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes);
+          const snappedPos = getSnappedPosition({ x: worldX, y: worldY }, hoveredNode, nodes, hoveredElement, elements, isShiftPressed);
 
           // Validation: Check if end node is same as start (prevent self-loops)
           if (hoveredNode && hoveredNode === drawingElement.startNode) {

--- a/2dfea/src/geometry/snapUtils.test.ts
+++ b/2dfea/src/geometry/snapUtils.test.ts
@@ -9,7 +9,13 @@
  * @see docs/plans/snap-to-element-projection.md §5.7, §8
  */
 import { describe, it, expect } from 'vitest';
-import { distanceToLineSegment, projectOntoSegment } from './snapUtils';
+import {
+  classifyNode,
+  distanceToLineSegment,
+  getSnappedPosition,
+  projectOntoSegment,
+} from './snapUtils';
+import type { Element, Node } from '../analysis/types';
 
 describe('projectOntoSegment', () => {
   it('projects a point onto the interior of a horizontal segment', () => {
@@ -121,6 +127,148 @@ describe('projectOntoSegment', () => {
         expect(perpDist).toBeLessThanOrEqual(1e-13);
       }
     }
+  });
+});
+
+describe('classifyNode', () => {
+  // Build a small graph: N1 (fixed) — E1 — N2 (free) — E2 — N3 (free); N4 isolated free
+  const baseElement = { E: 200, I: 1e-4, A: 1e-2 } as const;
+  const nodes: Node[] = [
+    { name: 'N1', x: 0, y: 0, support: 'fixed' },
+    { name: 'N2', x: 4, y: 0, support: 'free' },
+    { name: 'N3', x: 8, y: 0, support: 'free' },
+    { name: 'N4', x: 1, y: 5, support: 'free' },
+    { name: 'N5', x: 2, y: 5, support: 'pinned' },
+  ];
+  const elements: Element[] = [
+    { name: 'E1', nodeI: 'N1', nodeJ: 'N2', ...baseElement },
+    { name: 'E2', nodeI: 'N2', nodeJ: 'N3', ...baseElement },
+  ];
+
+  it('classifies a free node with no elements as free-end', () => {
+    expect(classifyNode('N4', nodes, elements)).toBe('free-end');
+  });
+
+  it('classifies a free node with exactly one element as free-end', () => {
+    // N3 has 1 element (E2) and support === 'free'
+    expect(classifyNode('N3', nodes, elements)).toBe('free-end');
+  });
+
+  it('classifies a free node with two or more elements as connected', () => {
+    // N2 has 2 elements (E1 + E2) and support === 'free' -> still connected
+    expect(classifyNode('N2', nodes, elements)).toBe('connected');
+  });
+
+  it('classifies a fixed-support node with no elements as connected (support overrides element count)', () => {
+    // N5 is pinned with 0 elements
+    expect(classifyNode('N5', nodes, elements)).toBe('connected');
+  });
+
+  it('classifies a fixed-support node with one element as connected', () => {
+    // N1 has 1 element (E1) and is fixed
+    expect(classifyNode('N1', nodes, elements)).toBe('connected');
+  });
+
+  it('returns free-end for a node name that is not in the array', () => {
+    expect(classifyNode('NONEXISTENT', nodes, elements)).toBe('free-end');
+  });
+});
+
+describe('getSnappedPosition', () => {
+  const baseElement = { E: 200, I: 1e-4, A: 1e-2 } as const;
+  const nodes: Node[] = [
+    { name: 'N1', x: 0, y: 0, support: 'fixed' },
+    { name: 'N2', x: 4, y: 0, support: 'free' },
+  ];
+  const elements: Element[] = [
+    { name: 'E1', nodeI: 'N1', nodeJ: 'N2', ...baseElement },
+  ];
+
+  it('returns exact node coordinates when a node is hovered (priority 1)', () => {
+    const result = getSnappedPosition({ x: 0.05, y: 0.05 }, 'N1', nodes);
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+  });
+
+  it('returns raw cursor coordinates when nothing is hovered', () => {
+    const result = getSnappedPosition({ x: 1.7, y: 0.4 }, null, nodes);
+    expect(result.x).toBe(1.7);
+    expect(result.y).toBe(0.4);
+  });
+
+  it('projects the cursor onto the hovered element when no node is hovered', () => {
+    // Cursor 0.1 m above the beam axis at x = 2 -> projection foot is (2, 0)
+    const result = getSnappedPosition(
+      { x: 2, y: 0.1 },
+      null,
+      nodes,
+      'E1',
+      elements,
+      false
+    );
+    expect(result.x).toBe(2);
+    expect(result.y).toBe(0);
+  });
+
+  it('node hover wins over element hover (priority 1 beats priority 2)', () => {
+    // Both hovered — should snap to node, not project onto element
+    const result = getSnappedPosition(
+      { x: 0.05, y: 0.05 },
+      'N1',
+      nodes,
+      'E1',
+      elements,
+      false
+    );
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+  });
+
+  it('falls through to raw cursor when bypassElementProjection is true (Shift held)', () => {
+    const result = getSnappedPosition(
+      { x: 2, y: 0.1 },
+      null,
+      nodes,
+      'E1',
+      elements,
+      true // Shift bypass
+    );
+    expect(result.x).toBe(2);
+    expect(result.y).toBe(0.1);
+  });
+
+  it('falls through to raw cursor when hoveredElement references a non-existent element', () => {
+    const result = getSnappedPosition(
+      { x: 2, y: 0.1 },
+      null,
+      nodes,
+      'E_GHOST',
+      elements,
+      false
+    );
+    expect(result.x).toBe(2);
+    expect(result.y).toBe(0.1);
+  });
+
+  it('falls through to raw cursor when an endpoint node of the hovered element is missing', () => {
+    const orphanElement: Element = { name: 'E_ORPHAN', nodeI: 'N1', nodeJ: 'GHOST', ...baseElement };
+    const result = getSnappedPosition(
+      { x: 2, y: 0.1 },
+      null,
+      nodes,
+      'E_ORPHAN',
+      [orphanElement],
+      false
+    );
+    expect(result.x).toBe(2);
+    expect(result.y).toBe(0.1);
+  });
+
+  it('is back-compatible — old 3-arg call still snaps to nodes only', () => {
+    // Defaults for hoveredElement/elements/bypass mean no element projection
+    const result = getSnappedPosition({ x: 2, y: 0.1 }, null, nodes);
+    expect(result.x).toBe(2);
+    expect(result.y).toBe(0.1);
   });
 });
 

--- a/2dfea/src/geometry/snapUtils.test.ts
+++ b/2dfea/src/geometry/snapUtils.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for snapUtils geometry helpers.
+ *
+ * The load-bearing test is the randomised tolerance assertion: it proves that
+ * `projectOntoSegment`'s IEEE-754 noise is at least three orders of magnitude
+ * tighter than PyNite's `PhysMember.descritize` tolerance of `1e-12 * (1 + L)`,
+ * so a projected node is guaranteed to trigger sub-member splitting on solve.
+ *
+ * @see docs/plans/snap-to-element-projection.md §5.7, §8
+ */
+import { describe, it, expect } from 'vitest';
+import { distanceToLineSegment, projectOntoSegment } from './snapUtils';
+
+describe('projectOntoSegment', () => {
+  it('projects a point onto the interior of a horizontal segment', () => {
+    const result = projectOntoSegment(
+      { x: 2, y: 1 },
+      { x: 0, y: 0 },
+      { x: 4, y: 0 }
+    );
+    expect(result.x).toBe(2);
+    expect(result.y).toBe(0);
+  });
+
+  it('clamps to the start endpoint when the projection would fall before it', () => {
+    const result = projectOntoSegment(
+      { x: -3, y: 5 },
+      { x: 0, y: 0 },
+      { x: 4, y: 0 }
+    );
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+  });
+
+  it('clamps to the end endpoint when the projection would fall past it', () => {
+    const result = projectOntoSegment(
+      { x: 10, y: -2 },
+      { x: 0, y: 0 },
+      { x: 4, y: 0 }
+    );
+    expect(result.x).toBe(4);
+    expect(result.y).toBe(0);
+  });
+
+  it('projects onto a vertical segment', () => {
+    const result = projectOntoSegment(
+      { x: 1, y: 2 },
+      { x: 0, y: 0 },
+      { x: 0, y: 4 }
+    );
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(2);
+  });
+
+  it('is symmetric for a mirrored horizontal segment', () => {
+    // Same geometry as the interior case but mirrored about y-axis
+    const result = projectOntoSegment(
+      { x: -2, y: 1 },
+      { x: 0, y: 0 },
+      { x: -4, y: 0 }
+    );
+    expect(result.x).toBe(-2);
+    expect(result.y).toBe(0);
+  });
+
+  it('projects onto a 45-degree diagonal segment (perpendicular foot at midpoint)', () => {
+    const result = projectOntoSegment(
+      { x: 4, y: 0 },
+      { x: 0, y: 0 },
+      { x: 4, y: 4 }
+    );
+    // The perpendicular foot from (4, 0) onto the line y = x lies at (2, 2)
+    expect(result.x).toBeCloseTo(2, 12);
+    expect(result.y).toBeCloseTo(2, 12);
+  });
+
+  it('returns lineStart for a zero-length (degenerate) segment without dividing by zero', () => {
+    const result = projectOntoSegment(
+      { x: 5, y: 7 },
+      { x: 2, y: 3 },
+      { x: 2, y: 3 }
+    );
+    expect(result.x).toBe(2);
+    expect(result.y).toBe(3);
+    expect(Number.isNaN(result.x)).toBe(false);
+    expect(Number.isNaN(result.y)).toBe(false);
+  });
+
+  it('is deterministic — identical inputs produce identical outputs across calls', () => {
+    const a = projectOntoSegment({ x: 1.7, y: 0.4 }, { x: 0, y: 0 }, { x: 3, y: 0 });
+    const b = projectOntoSegment({ x: 1.7, y: 0.4 }, { x: 0, y: 0 }, { x: 3, y: 0 });
+    expect(a.x).toBe(b.x);
+    expect(a.y).toBe(b.y);
+  });
+
+  // Load-bearing tolerance test: proves projection noise is well below PyNite's
+  // PhysMember.descritize tolerance of 1e-12 * (1 + L) for any reasonable L.
+  it('produces projections whose perpendicular distance is <= 1e-13 m for L between 0.1 m and 1000 m', () => {
+    const lengths = [0.1, 1, 10, 100, 1000];
+    const samplesPerLength = 50;
+    // Deterministic pseudo-random offsets so the test is reproducible
+    let seed = 0x2dfea;
+    const rand = () => {
+      // xorshift32
+      seed ^= seed << 13;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5;
+      // map to [-10, 10]
+      return ((seed >>> 0) / 0xffffffff) * 20 - 10;
+    };
+
+    for (const L of lengths) {
+      const lineStart = { x: 0, y: 0 };
+      const lineEnd = { x: L, y: 0 };
+      for (let i = 0; i < samplesPerLength; i++) {
+        // Cursor anywhere within ±10 m of the midpoint
+        const cursor = { x: L / 2 + rand(), y: rand() };
+        const proj = projectOntoSegment(cursor, lineStart, lineEnd);
+        // Perpendicular distance from the projection back to the segment
+        const perpDist = distanceToLineSegment(proj, lineStart, lineEnd);
+        expect(perpDist).toBeLessThanOrEqual(1e-13);
+      }
+    }
+  });
+});
+
+describe('distanceToLineSegment (refactored to delegate to projectOntoSegment)', () => {
+  it('returns 0 for a point exactly on the segment', () => {
+    expect(
+      distanceToLineSegment({ x: 2, y: 0 }, { x: 0, y: 0 }, { x: 4, y: 0 })
+    ).toBe(0);
+  });
+
+  it('returns the perpendicular distance for an interior projection', () => {
+    expect(
+      distanceToLineSegment({ x: 2, y: 3 }, { x: 0, y: 0 }, { x: 4, y: 0 })
+    ).toBe(3);
+  });
+
+  it('returns the distance to the start endpoint when projection clamps there', () => {
+    // Cursor at (-3, 4); start at (0, 0) -> distance = sqrt(9 + 16) = 5
+    expect(
+      distanceToLineSegment({ x: -3, y: 4 }, { x: 0, y: 0 }, { x: 4, y: 0 })
+    ).toBe(5);
+  });
+
+  it('returns the distance to lineStart for a zero-length segment', () => {
+    // sqrt((5-2)^2 + (7-3)^2) = sqrt(9 + 16) = 5
+    expect(
+      distanceToLineSegment({ x: 5, y: 7 }, { x: 2, y: 3 }, { x: 2, y: 3 })
+    ).toBe(5);
+  });
+});

--- a/2dfea/src/geometry/snapUtils.ts
+++ b/2dfea/src/geometry/snapUtils.ts
@@ -91,7 +91,62 @@ export function findNearestElement(
 }
 
 /**
- * Calculate perpendicular distance from a point to a line segment
+ * Project a point onto a line segment, clamped to the segment's [0, 1] parametric range.
+ *
+ * Returns the closest point on the segment to the input point. If the segment is degenerate
+ * (zero length), returns `lineStart`.
+ *
+ * Single source of truth for the projection math used by both `distanceToLineSegment`
+ * (UI hover detection) and `getSnappedPosition` (click placement). The hover threshold
+ * is loose (~0.2 m world at default zoom); precision comes from this projection, not
+ * the threshold.
+ *
+ * IEEE-754 noise: ~4e-15 m absolute for L = 4 m (relative ~1e-15). Three orders of
+ * magnitude tighter than PyNite's `PhysMember.descritize` tolerance of `1e-12 * (1 + L)`,
+ * so projected nodes reliably trigger sub-member splitting on solve. Verified for L
+ * between 0.1 m and 1000 m by the randomised tolerance test in `snapUtils.test.ts`.
+ *
+ * @see docs/plans/snap-to-element-projection.md §5.2, §5.7
+ *
+ * @param point - Point to project
+ * @param lineStart - Start of line segment
+ * @param lineEnd - End of line segment
+ * @returns The closest point on the segment (clamped to endpoints).
+ */
+export function projectOntoSegment(
+  point: Point,
+  lineStart: Point,
+  lineEnd: Point
+): Point {
+  const dx = lineEnd.x - lineStart.x;
+  const dy = lineEnd.y - lineStart.y;
+  const lengthSquared = dx * dx + dy * dy;
+
+  // Degenerate (zero-length) segment — return the start point
+  if (lengthSquared === 0) {
+    return { x: lineStart.x, y: lineStart.y };
+  }
+
+  // Parameter t along the segment: 0 at lineStart, 1 at lineEnd. Clamped to the segment.
+  const t = Math.max(
+    0,
+    Math.min(
+      1,
+      ((point.x - lineStart.x) * dx + (point.y - lineStart.y) * dy) / lengthSquared
+    )
+  );
+
+  return {
+    x: lineStart.x + t * dx,
+    y: lineStart.y + t * dy,
+  };
+}
+
+/**
+ * Calculate perpendicular distance from a point to a line segment.
+ *
+ * Thin wrapper over `projectOntoSegment` — the projection math lives in one place.
+ *
  * @param point - Point to measure from
  * @param lineStart - Start point of line segment
  * @param lineEnd - End point of line segment
@@ -102,28 +157,5 @@ export function distanceToLineSegment(
   lineStart: Point,
   lineEnd: Point
 ): number {
-  const dx = lineEnd.x - lineStart.x;
-  const dy = lineEnd.y - lineStart.y;
-  const lengthSquared = dx * dx + dy * dy;
-
-  // If the line segment is actually a point
-  if (lengthSquared === 0) {
-    return distance(point, lineStart);
-  }
-
-  // Parameter t represents position along line (0 = start, 1 = end)
-  // This projects the point onto the line
-  const t = Math.max(
-    0,
-    Math.min(
-      1,
-      ((point.x - lineStart.x) * dx + (point.y - lineStart.y) * dy) / lengthSquared
-    )
-  );
-
-  // Point on the line segment closest to the input point
-  const projectionX = lineStart.x + t * dx;
-  const projectionY = lineStart.y + t * dy;
-
-  return distance(point, { x: projectionX, y: projectionY });
+  return distance(point, projectOntoSegment(point, lineStart, lineEnd));
 }

--- a/2dfea/src/geometry/snapUtils.ts
+++ b/2dfea/src/geometry/snapUtils.ts
@@ -6,25 +6,111 @@ import type { Node, Element } from '../analysis/types';
 import { distance, type Point } from './transformUtils';
 
 /**
- * Get snapped position - returns node coordinates if hovering over a node, else cursor position
- * This is the centralized snapping behavior used by all tools
- * @param worldPos - Current cursor position in world coordinates
+ * Get the snapped click coordinates given the current cursor position and hover state.
+ *
+ * Centralised snapping behaviour used by every click-driven tool (draw-node,
+ * draw-element, move command). Priority order:
+ *
+ *   1. **Node snap.** If a node is hovered, return that node's exact coordinates.
+ *      Existing junctions / supports always win — preserves the historical
+ *      snap-to-node UX that users rely on.
+ *   2. **Element-projection snap.** Else, if an element is hovered AND
+ *      `bypassElementProjection` is `false`, project the cursor onto the
+ *      element's axis (clamped to the segment's [0, 1] parametric range) and
+ *      return the projection foot. This places new mid-span nodes exactly on
+ *      the element's axis, well within PyNite's `PhysMember.descritize`
+ *      tolerance of `1e-12 * (1 + L)`, so the physical member auto-splits at
+ *      the new node on solve.
+ *   3. **Raw cursor.** Else, return the unmodified `worldPos`. Also the
+ *      fallback when `bypassElementProjection` is `true` (Shift held), or
+ *      when the hovered element / its endpoint nodes can no longer be found.
+ *
+ * Tie-breaking when multiple elements overlap: `findNearestElement` (the
+ * function that populates `hoveredElement`) deterministically returns the
+ * element with the smallest perpendicular distance, so the projection
+ * naturally lands on whichever element the user appears to be targeting.
+ *
+ * Shift-bypass contract: callers pass the click-event `shiftKey` value as
+ * `bypassElementProjection`. Holding Shift suppresses the projection so the
+ * user can place a node intentionally off-axis.
+ *
+ * @see docs/plans/snap-to-element-projection.md §5.3, §5.4, §5.6
+ *
+ * @param worldPos - Current cursor position in world coordinates (m)
  * @param hoveredNode - Name of hovered node (if any)
  * @param nodes - Array of all nodes
+ * @param hoveredElement - Name of hovered element (if any). Default `null` for
+ *   back-compat with callers that have not yet been migrated.
+ * @param elements - Array of all elements. Default `[]`.
+ * @param bypassElementProjection - When `true`, skip element-projection and
+ *   fall through to raw cursor coordinates. Default `false`.
  * @returns Snapped coordinates
  */
 export function getSnappedPosition(
   worldPos: Point,
   hoveredNode: string | null,
-  nodes: Node[]
+  nodes: Node[],
+  hoveredElement: string | null = null,
+  elements: Element[] = [],
+  bypassElementProjection = false
 ): Point {
+  // 1. Node snap — exact node coordinates always win
   if (hoveredNode) {
-    const node = nodes.find(n => n.name === hoveredNode);
+    const node = nodes.find((n) => n.name === hoveredNode);
     if (node) {
       return { x: node.x, y: node.y };
     }
   }
+
+  // 2. Element-projection snap — only when no node is hovered and not bypassed
+  if (hoveredElement && !bypassElementProjection) {
+    const element = elements.find((e) => e.name === hoveredElement);
+    if (element) {
+      const nodeI = nodes.find((n) => n.name === element.nodeI);
+      const nodeJ = nodes.find((n) => n.name === element.nodeJ);
+      if (nodeI && nodeJ) {
+        return projectOntoSegment(
+          worldPos,
+          { x: nodeI.x, y: nodeI.y },
+          { x: nodeJ.x, y: nodeJ.y }
+        );
+      }
+    }
+  }
+
+  // 3. Raw cursor — fallback
   return worldPos;
+}
+
+/**
+ * Snap-state classification for an existing node, used by the canvas snap-marker
+ * to colour-code the click target:
+ *
+ *   - `'connected'` — node has >=2 attached elements OR a non-`free` support.
+ *     Marker renders green: clicking reuses an established junction.
+ *   - `'free-end'` — node has <=1 attached element AND `support === 'free'`.
+ *     Marker renders amber: clicking reuses a possibly-dangling node, which is
+ *     worth flagging visually.
+ *
+ * O(n_elements) per call — negligible for any realistic model. Intended to be
+ * called once per mousemove from the snap-marker render block.
+ *
+ * @see docs/plans/snap-to-element-projection.md §5.5
+ */
+export type NodeSnapState = 'connected' | 'free-end';
+
+export function classifyNode(
+  nodeName: string,
+  nodes: Node[],
+  elements: Element[]
+): NodeSnapState {
+  const node = nodes.find((n) => n.name === nodeName);
+  if (!node) return 'free-end';
+  const elementCount = elements.filter(
+    (e) => e.nodeI === nodeName || e.nodeJ === nodeName
+  ).length;
+  const isSupported = node.support !== 'free';
+  return elementCount >= 2 || isSupported ? 'connected' : 'free-end';
 }
 
 /**

--- a/2dfea/src/store/useUIStore.ts
+++ b/2dfea/src/store/useUIStore.ts
@@ -116,6 +116,12 @@ export interface UIState {
   toggleSnapToElements: () => void;
   setSnapTolerance: (tolerance: number) => void;
 
+  // Shift-bypass for element-projection snap (plan: snap-to-element-projection §5.5).
+  // Tracked via window-level keydown/keyup listeners in CanvasView so the snap
+  // marker disappears immediately on Shift press without needing cursor motion.
+  isShiftHeld: boolean;
+  setIsShiftHeld: (held: boolean) => void;
+
   // Hover state (for snapping feedback)
   hoveredNode: string | null;
   hoveredElement: string | null;
@@ -297,7 +303,8 @@ const initialState = {
   snapEnabled: true,
   snapToNodes: true,
   snapToElements: true,
-  snapTolerance: 10,  // pixels
+  snapTolerance: 10,  // pixels — UX hover-detection threshold; do NOT tighten
+  isShiftHeld: false,
   hoveredNode: null,
   hoveredElement: null,
   hoveredLoad: null,
@@ -532,6 +539,10 @@ export const useUIStore = create<UIState>()(
 
       setSnapTolerance: (tolerance) => {
         set({ snapTolerance: tolerance });
+      },
+
+      setIsShiftHeld: (held) => {
+        set({ isShiftHeld: held });
       },
 
       // Hover state actions


### PR DESCRIPTION
## Summary
Closes the latent UX-vs-physics gap that prevented T-joint and mid-span node placements from triggering PyNite's `PhysMember.descritize()` auto-split. Today's snap detected element hover but used raw cursor coordinates on click — leaving new nodes up to ~10 cm off-axis. PyNite needs ~1×10⁻¹² m perpendicular accuracy.

- **Geometric fix**: when the user clicks while hovering an element (and no node is hovered), project the cursor onto the line via the new `projectOntoSegment` helper. IEEE-754 noise ~4×10⁻¹⁵ m for L=4 m — three orders tighter than PyNite's tolerance. UI hover threshold (`snapTolerance: 10 px`) unchanged.
- **Tri-colour snap marker** signalling what the next click resolves to: **blue** (new point on an element), **green** (existing connected node — ≥2 elements OR has support), **amber** (existing free-end node). Replaces the legacy cyan-fill node-hover treatment when snap is active; legacy cyan still renders as a fallback when global snap is off or Shift is held.
- **Shift bypass** on all five `getSnappedPosition` call sites (Draw + Move). Window-level keydown/keyup listener so the marker disappears on Shift press without cursor motion.
- **Move command** projects on **both** base-point and endpoint clicks (CAD osnap convention).
- **No PyNite, worker, or data-model changes.** `Element` stays a single entity with two endpoints; PyNite handles the split on solve via `PhysMember.descritize()`. Verified end-to-end during manual QA — moment/shear diagram is continuous across the projected node, proving the auto-split fired.

## Plan of record
[2dfea/docs/plans/snap-to-element-projection.md](https://github.com/magnusfjeldolsen/structural_tools/blob/master/2dfea/docs/plans/snap-to-element-projection.md)

## Change class
2dfea-only. Will trigger \`.github/workflows/deploy-all-modules.yml\` on merge — live at https://magnusfjeldolsen.github.io/structural_tools/2dfea/ within 1–2 minutes.

## Test plan
- [x] \`cd 2dfea && npm run type-check\` — green
- [x] \`cd 2dfea && npm run build\` — +0.41 KB gzipped (under 1 KB budget)
- [x] \`cd 2dfea && npm test\` — 79 passing across 9 files (+27 vs baseline 52)
- [x] Manual QA Group A — drop node mid-span, run analysis → diagrams continuous across projected node (PyNite auto-split fired)
- [x] Manual QA Group B — T-joint via \`draw-element\` second click on a beam
- [x] Manual QA Group C — Shift bypass; analysis correctly does NOT split when bypassed
- [x] Manual QA Group D — Move command projects on both base point and endpoint
- [x] Manual QA Group E — tri-colour marker (blue / green / amber) after hover-clash fix (\`ca7fbde\`)
- [ ] Post-merge: GitHub Actions deploy green; site live within 1–2 min

## Rollback
\`git revert <merge-sha> && git push origin master\` — gh-pages auto-redeploys the previous build. No schema migration risk; no data-model change.

## Follow-ups (not in this PR)
- Additional snap targets (midpoint, perpendicular foot from another point, intersection of two elements, parallel snap) — layer on top of \`projectOntoSegment\` later.
- Auto-heal for existing off-line nodes (no, intentional non-goal — only changes click-time placement).
- Visual styling tweaks if final colour palette gets a design review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)