### PR TITLE
ci: add pr-checks workflow and gate deploy on Vitest suite

### DIFF
--- a/.github/workflows/deploy-all-modules.yml
+++ b/.github/workflows/deploy-all-modules.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install 2dfea dependencies
         working-directory: 2dfea
@@ -61,6 +61,10 @@ jobs:
       - name: Run 2dfea type check
         working-directory: 2dfea
         run: npm run type-check
+
+      - name: Run 2dfea Vitest suite
+        working-directory: 2dfea
+        run: npm test
 
       - name: Build 2dfea application
         working-directory: 2dfea

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,52 @@
+name: PR checks
+
+# Pre-merge gates for the 2dfea module: type-check, build, and test.
+# Configure as a required status check in
+#   Settings → Branches → Branch protection rules → master
+# so the merge button only enables after this run goes green.
+
+on:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - '2dfea/**'
+      - '.github/workflows/pr-checks.yml'
+      - '.github/workflows/deploy-all-modules.yml'
+
+# Cancel older runs of the same PR when new commits are pushed
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-2dfea:
+    name: 2dfea type-check + build + test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install 2dfea dependencies
+        working-directory: 2dfea
+        run: npm ci
+        env:
+          CI: true
+
+      - name: Run 2dfea type check
+        working-directory: 2dfea
+        run: npm run type-check
+
+      - name: Build 2dfea application
+        working-directory: 2dfea
+        run: npm run build
+        env:
+          NODE_ENV: production
+
+      - name: Run 2dfea Vitest suite
+        working-directory: 2dfea
+        run: npm test


### PR DESCRIPTION
## Summary
Two CI hardening changes for the 2dfea module:

1. **New `.github/workflows/pr-checks.yml`** runs on \`pull_request\` events touching \`2dfea/**\` or the workflow files. Pipeline: \`npm ci\` → \`npm run type-check\` → \`npm run build\` → \`npm test\` on Node 20. Concurrency group cancels older runs when new commits land on the PR.
2. **`.github/workflows/deploy-all-modules.yml`** bumped Node 18 → Node 20 (silences \`EBADENGINE\` warnings; vitest 3.x deps need ≥ 20), and now runs \`npm test\` between type-check and build. Failed tests block the deploy → gh-pages stays on the previous build if a regression slips through PR checks.

## Self-validation
This PR's own diff matches the path filter (\`.github/workflows/pr-checks.yml\` and \`.github/workflows/deploy-all-modules.yml\`), so \`pr-checks.yml\` should fire on this PR and validate itself end-to-end. If the run is green, we know the workflow is syntactically correct and all four gates work.

## Branch protection (manual one-time follow-up after merge)
After this lands, configure branch protection on \`master\`:
- **Settings → Branches → Branch protection rules → Add rule**
- Branch name pattern: \`master\`
- ☑ Require status checks to pass before merging
- ☑ Require branches to be up to date before merging
- Search for \`2dfea type-check + build + test\` and select it

This is the piece that actually blocks the merge button. Without it, the workflow runs but doesn't gate.

## Test plan
- [ ] \`pr-checks.yml\` fires on this PR and goes green (self-validation)
- [ ] After merge: \`deploy-all-modules.yml\` runs with the new Node 20 + test step → green
- [ ] After merge: configure branch protection rule (manual GitHub Settings click)
- [ ] Open a tiny follow-up PR (e.g. typo fix in a 2dfea source file) to verify the rule blocks merge until checks pass

## Rollback
\`git revert <merge-sha> && git push origin master\` — gh-pages auto-redeploys the previous build. Branch protection rule (if configured) can be removed via GitHub Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)