### PR TITLE
fix(2dfea): release flow — canvas re-render + analyzer Rz pin

### DIFF
--- a/2dfea/public/python/pynite_analyzer.py
+++ b/2dfea/public/python/pynite_analyzer.py
@@ -45,10 +45,36 @@ class PyNiteWebAnalyzer:
             self.model.add_node(node['name'], float(node['x']), float(node['y']), 0.0)
             print(f"  Added node: {node['name']} at ({node['x']}, {node['y']})")
 
+        # Compute Rz suppliers per node BEFORE adding supports. A node "loses"
+        # Rz stiffness from an element only at the end where Rz is released. If
+        # ALL connecting elements release Rz at this node AND the support does
+        # not already constrain Rz, the global stiffness matrix has a singular
+        # Rz row at this node and PyNite raises "Unstable nodes". Physically the
+        # rotation at such a node is uncoupled from every element (the moment
+        # transmitted to/from this node is zero by definition of the release),
+        # so pinning Rz to zero is a safe regularisation that does not change
+        # the kinematic result. Without this pin, the cantilever-tip release
+        # case (single element with Rz released at its free-end node) cannot
+        # be solved.
+        rz_suppliers = {n['name']: 0 for n in nodes}
+        for el in elements:
+            if not bool(el.get('releaseStartMz')):
+                rz_suppliers[el['nodeI']] = rz_suppliers.get(el['nodeI'], 0) + 1
+            if not bool(el.get('releaseEndMz')):
+                rz_suppliers[el['nodeJ']] = rz_suppliers.get(el['nodeJ'], 0) + 1
+
         # Add supports BEFORE elements (PyNite requirement!)
         print(f"\nAdding supports:")
         for node in nodes:
-            self._add_support(node['name'], node['support'])
+            name = node['name']
+            sup = node['support']
+            # Only 'fixed' constrains Rz natively; for any other support, we
+            # need an implicit Rz pin when the node has lost all element-side
+            # Rz stiffness due to releases.
+            pin_rz = rz_suppliers.get(name, 0) == 0 and sup != 'fixed'
+            self._add_support(name, sup, pin_rz=pin_rz)
+            if pin_rz:
+                print(f"  ⚠ Implicit Rz pin at {name}: every connecting element-end releases Mz; pinning rotation to keep matrix non-singular.")
 
         # Add elements with unique material and section properties per element
         print(f"\nAdding {len(elements)} elements:")
@@ -124,9 +150,15 @@ class PyNiteWebAnalyzer:
                 if any([float(load['fx']) != 0, float(load['fy']) != 0, float(load['mz']) != 0]):
                     self._add_nodal_load(load)
 
-    def _add_support(self, node_name: str, support_type: str):
-        """Add support constraints to a node"""
-        print(f"Adding support: {node_name} = {support_type}")
+    def _add_support(self, node_name: str, support_type: str, pin_rz: bool = False):
+        """Add support constraints to a node.
+
+        pin_rz: if True, force the Rz (rotation about z) DOF to be constrained
+        regardless of the support type's native Rz behaviour. Used by the
+        caller to break a singular DOF created when every element-end at this
+        node releases Mz. See create_model() for the rationale.
+        """
+        print(f"Adding support: {node_name} = {support_type}{' [+Rz pin]' if pin_rz else ''}")
         if support_type == 'fixed':
             dx = True # constrained for translation in x
             dy = True # constrained for translation in y
@@ -143,29 +175,37 @@ class PyNiteWebAnalyzer:
             dz = True # constrained for translation in z
             rx = True # constrained for rotation about x
             ry = True # constrained for rotation about y
-            rz = False # constrained for rotation about z
+            rz = pin_rz # released-end induced pin only
             self.model.def_support(node_name, dx, dy, dz, rx, ry, rz)
 
         elif support_type == 'roller-x':
-            dx = False # constrained for translation in x
+            dx = False # free in x (this support type is rolling in x)
             dy = True # constrained for translation in y
             dz = True # constrained for translation in z
             rx = True # constrained for rotation about x
             ry = True # constrained for rotation about y
-            rz = False # constrained for rotation about z
+            rz = pin_rz # released-end induced pin only
 
-            self.model.def_support(node_name, False, True, True, True, False, False)
+            self.model.def_support(node_name, dx, dy, dz, rx, ry, rz)
 
         elif support_type == 'roller-y':
 
             dx = True # constrained for translation in x
-            dy = False # constrained for translation in y
+            dy = False # free in y (this support type is rolling in y)
             dz = True # constrained for translation in z
             rx = True # constrained for rotation about x
             ry = True # constrained for rotation about y
-            rz = False # constrained for rotation about z
+            rz = pin_rz # released-end induced pin only
 
-            self.model.def_support(node_name, True, False, True, True, False, False)
+            self.model.def_support(node_name, dx, dy, dz, rx, ry, rz)
+
+        elif support_type == 'free':
+            # Originally no def_support call. With an implicit Rz pin we
+            # constrain only the Rz DOF so the matrix is well-conditioned;
+            # the other DOFs remain free and are constrained by the element's
+            # stiffness contributions at this node.
+            if pin_rz:
+                self.model.def_support(node_name, False, False, False, False, False, True)
 
         elif support_type == 'free':
             # Free node - no constraints

--- a/2dfea/src/components/CanvasView.tsx
+++ b/2dfea/src/components/CanvasView.tsx
@@ -61,6 +61,12 @@ export function CanvasView({ width, height }: CanvasViewProps) {
   const getResultsForCase = useModelStore((state) => state.getResultsForCase);
   const getResultsForCombination = useModelStore((state) => state.getResultsForCombination);
   const analysisResults = useModelStore((state) => state.analysisResults);  // Keep for backward compat
+  // Subscribe to the cache version so the canvas re-renders when runFullAnalysis
+  // writes a new ResultsCache reference. Without this, getActiveResults() can read
+  // stale (cleared) data because the component never wakes up after the cache write.
+  // See debugging session 2026-05-05.
+  const resultsCacheVersion = useModelStore((state) => state.resultsCache.lastUpdated);
+  void resultsCacheVersion;
   const selectedNodes = useModelStore((state) => state.selectedNodes);
   const selectedElements = useModelStore((state) => state.selectedElements);
   const nextNodeNumber = useModelStore((state) => state.nextNodeNumber);


### PR DESCRIPTION
## Summary

Two bugs surfaced during interactive QA of the member-end-releases-mz feature. Both were latent on master before the release feature shipped; the release-flag mutation flow just made them reliably reproducible. Both are tiny.

### Bug 1 — Canvas didn't re-render after `runFullAnalysis` (`b771f38`)

`runFullAnalysis` writes only `state.resultsCache`, never `state.analysisResults`. `CanvasView.tsx` was subscribed to `analysisResults` and `activeResultView` only, so after a cache invalidation (release toggle, E/I/A edit) followed by a fresh analysis, the canvas didn't wake up — diagrams stayed invisible until something else triggered a re-render (most commonly `hoveredNode`/`hoveredElement` from mouse movement, which masked the bug interactively).

Fix: subscribe to `state.resultsCache.lastUpdated`. The selector returns a number that changes on every cache write (and back to `0` on invalidation), so any cache mutation triggers a re-render. Reading the binding via `void` silences the unused-variable lint without a no-op expression.

### Bug 2 — Cantilever-tip release reported "Unstable nodes" (`e4bcc57`)

PyNite's `def_releases` zeroes the released DOF's contribution to the local stiffness matrix but does not eliminate the corresponding global DOF. When every element-end at a node releases Mz and the node's support does not natively constrain Rz (anything other than `fixed`), the assembled stiffness matrix has a singular row at that node and PyNite refuses to solve, even when the release is physically a no-op (the moment at a free tip is already zero).

Fix: in `create_model`, pre-compute `rz_suppliers` per node (count of element-ends connecting to the node where Rz is NOT released). When that count is zero AND the support is not `fixed`, pass `pin_rz=True` to `_add_support`, which forces `rz=True` on the `def_support` call. The `free` support type previously skipped `def_support` entirely; with `pin_rz` we issue a `def_support` that constrains only Rz.

Why it's safe: when every connecting element releases Mz at the node, no element references the global Rz of that node (`def_releases` removes the contribution). Pinning the phantom DOF to zero cannot change any internal force, moment, or deflection — it just keeps the matrix invertible.

## Verified

- `cd 2dfea && npm run type-check` clean
- `cd 2dfea && npm test` — 89/89 passing
- Chrome session reproduction:
  - Cantilever (N1 fixed, N2 free, tip load 10 kN). Without release: Dead Mz_i = 40 kNm. With `releaseEndMz: true` on E1: Dead Mz_i = 40 kNm, identical moment array `[40, 36, 32, ..., 4, 0]` — release is a correct no-op physically.
  - Cache invalidation via `updateElement({ I: ... })` followed by `runFullAnalysis()` now triggers an automatic canvas re-render of the moment diagram (no mouse movement needed).

## Deployment impact

2dfea-only. Triggers `deploy-all-modules.yml` on merge to master. No schema or workflow changes.

## Rollback

Single-commit revert of either commit independently; redeploy ≈ 3 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)