### PR TITLE
feat(warnings): flag unfinished modules (THP, fastener group, cable designer)

### DIFF
--- a/THP/index.html
+++ b/THP/index.html
@@ -49,6 +49,14 @@
 <body class="bg-gray-900 text-gray-100 font-sans min-h-screen hero-bg">
 
   <main class="w-full max-w-6xl mx-auto p-6">
+    <!-- UNFINISHED WARNING -->
+    <div class="mb-6 flex items-start gap-3 px-5 py-4 bg-red-600 border-2 border-red-400 rounded-lg shadow-lg">
+      <svg class="w-7 h-7 text-white flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+      <div>
+        <h3 class="text-white font-bold text-base">⚠ Unfinished calculator — do not use for design</h3>
+        <p class="text-red-100 text-sm mt-1">This module is incomplete and may produce <strong>incorrect results</strong>. Verify everything independently.</p>
+      </div>
+    </div>
     <!-- Header -->
     <div class="flex justify-end mb-4">
       <a href="../index.html" class="text-blue-400 hover:text-blue-300 text-sm transition">

--- a/cable_designer/index.html
+++ b/cable_designer/index.html
@@ -71,15 +71,15 @@
   </header>
 
   <!-- WARNING BANNER ─────────────────────────────────────────────────────── -->
-  <div class="flex-none bg-amber-500 border-b-2 border-amber-600 px-6 py-3">
+  <div class="flex-none bg-red-600 border-b-2 border-red-400 px-6 py-3">
     <div class="flex items-start gap-3">
-      <svg class="w-6 h-6 text-amber-900 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+      <svg class="w-6 h-6 text-white flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
         <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
       </svg>
       <div class="flex-1">
-        <h3 class="text-amber-900 font-semibold text-sm">Work in Progress</h3>
-        <p class="text-amber-900 text-sm mt-1">
-          This tool is currently under development and may not work correctly. Features are being tested and results should be verified independently.
+        <h3 class="text-white font-bold text-sm">⚠ Unfinished — do not use for design</h3>
+        <p class="text-red-100 text-sm mt-1">
+          This tool is incomplete and may produce <strong>incorrect results</strong>. Verify everything independently before relying on any output.
         </p>
       </div>
     </div>

--- a/concretefastenergroup/index.html
+++ b/concretefastenergroup/index.html
@@ -35,8 +35,8 @@
         <header class="app-header">
             <h1>EC2 Part 4 Fastener Design Calculator</h1>
             <p class="subtitle">CEN/TS 1992-4-1:2009 & 1992-4-2:2009</p>
-            <p class="warning-banner" style="background: #fff3cd; color: #856404; padding: 0.75rem; margin: 0.5rem 0; border-radius: 4px; border: 1px solid #ffeaa7;">
-                ⚠️ <strong>Under Development:</strong> This calculator is currently in development and may not produce correct results. Use at your own risk and verify all outputs independently.
+            <p class="warning-banner" style="background: #dc2626; color: #ffffff; padding: 0.9rem; margin: 0.5rem 0; border-radius: 6px; border: 2px solid #fca5a5; font-weight: 600;">
+                ⚠️ <strong>UNFINISHED — DO NOT USE FOR DESIGN:</strong> This calculator is incomplete and may produce <strong>incorrect results</strong>. Verify all outputs independently.
             </p>
         </header>
 

--- a/index.html
+++ b/index.html
@@ -543,6 +543,11 @@
 
         <!-- Two-Sided Hat Profile Tool -->
         <div class="tool-card rounded-xl p-8">
+          <!-- UNFINISHED WARNING -->
+          <div class="mb-4 flex items-center gap-2 px-4 py-2 bg-red-600 border-2 border-red-400 rounded-lg">
+            <svg class="w-5 h-5 text-white flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+            <span class="text-white text-sm font-bold">⚠ UNFINISHED — may produce INCORRECT results. Not for design use.</span>
+          </div>
           <div class="flex items-center mb-4">
             <div class="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1014,6 +1019,11 @@
       <div class="grid md:grid-cols-1 gap-8 mb-8">
         <!-- Concrete Fastener Group Design Calculator -->
         <div class="tool-card rounded-xl p-8">
+          <!-- UNFINISHED WARNING -->
+          <div class="mb-4 flex items-center gap-2 px-4 py-2 bg-red-600 border-2 border-red-400 rounded-lg">
+            <svg class="w-5 h-5 text-white flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+            <span class="text-white text-sm font-bold">⚠ UNFINISHED — may produce INCORRECT results. Not for design use.</span>
+          </div>
           <div class="flex items-center mb-4">
             <div class="w-12 h-12 bg-rose-500 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1238,6 +1248,11 @@
 
         <!-- Cable Designer -->
         <div class="tool-card rounded-xl p-8">
+          <!-- UNFINISHED WARNING -->
+          <div class="mb-4 flex items-center gap-2 px-4 py-2 bg-red-600 border-2 border-red-400 rounded-lg">
+            <svg class="w-5 h-5 text-white flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+            <span class="text-white text-sm font-bold">⚠ UNFINISHED — may produce INCORRECT results. Not for design use.</span>
+          </div>
           <div class="flex items-center mb-4">
             <div class="w-12 h-12 bg-sky-500 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Why

Three modules are incomplete and can produce incorrect results, but were presented to users with **no clear warning** (or only a mild one). This makes the unfinished status unmistakable.

## Changes

Loud red **\"UNFINISHED — may produce incorrect results / do not use for design\"** banner added in two places per module:

| Module | Front-page card | In-module banner |
|--------|----------------|------------------|
| **THP** (Two-Sided Hat Profile) | added (had none) | added (had none) |
| **Concrete Fastener Group** | added (had none) | upgraded mild yellow → red |
| **Cable Designer** | added (had none) | upgraded amber → red |

## Verification

- Banners render at top of each card and at the top of each module page.
- HTML-only change; no 2dfea code touched (the required CI check will detect this and skip the heavy build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)