### PR TITLE
feat: wall minimum reinforcement module (EC2 + Norwegian NA)

### DIFF
--- a/.github/workflows/deploy-all-modules.yml
+++ b/.github/workflows/deploy-all-modules.yml
@@ -99,6 +99,7 @@ jobs:
                      concrete_base_plate_compressive_design \
                      concrete_dowels \
                      concrete_minimum_reinforcement \
+                     concrete_wall_minimum_reinforcement \
                      concrete_slab_design \
                      steel_beam_relative_deisgn \
                      steel_cross_section_database \

--- a/concrete_wall_minimum_reinforcement/README.md
+++ b/concrete_wall_minimum_reinforcement/README.md
@@ -46,6 +46,22 @@ And the same wall under different requirements, at ø16:
 overridable. For a single central layer the code leg doubles, since 9.6.3(1) asks for the
 amount at each surface and one layer serves both.
 
+The two k values are worth understanding rather than accepting. EC2's own recommendation is
+a flat `As,hmin = 0,001·Ac`. The Norwegian NA replaces it with a strength-dependent form,
+and the interior value reproduces the EC2 figure almost exactly:
+
+| class | fctm | `0,15·fctm/fyk` (interior) | `0,30·fctm/fyk` (exterior) | EC2 recommended |
+|---|---|---|---|---|
+| B25 | 2,57 | 0,077 % | 0,154 % | 0,100 % |
+| B30 | 2,90 | 0,087 % | 0,174 % | 0,100 % |
+| B35 | 3,21 | 0,096 % | 0,193 % | 0,100 % |
+| B45 | 3,80 | 0,114 % | 0,228 % | 0,100 % |
+
+So 0,15 is not a halving of 0,30 — it *is* the EC2 baseline, re-expressed so the minimum
+scales with the force that cracks the section. 0,30 is a deliberate doubling for walls
+exposed to outdoor climate, where the imposed strain is roughly twice as large. Anything
+weather-exposed or cast against soil is normally taken as exterior.
+
 **Crack control, §7.3.2** — `As,min·σs = kc·k·fct,eff·Act`, with an absolute floor at
 `σs = fyk` that no crack-width relaxation can go below. Two routes, both computed always:
 
@@ -90,6 +106,10 @@ number on the adjacent row, and says plainly which is which.
   wall they are normally the outer layer for exactly that reason.
 - **fctm** uses the closed form `0,30·fck^(2/3)`, not the rounded Table 3.1 value, so results
   sit about 0,3 % above a hand check using fctm = 3,2 for B35.
+- **Exterior vs interior** only decides the answer when crack control is switched off. With
+  §7.3.2 active the crack requirement normally sits well above both legs, and the choice
+  stops mattering — for t = 400, B35, ø12 it is c145 against c290 with no crack control,
+  and c60 either way at wk 0,30.
 - Values taken from the Norwegian NA should be confirmed against your own copy of NA:2010.
 
 ## Files

--- a/concrete_wall_minimum_reinforcement/README.md
+++ b/concrete_wall_minimum_reinforcement/README.md
@@ -1,0 +1,106 @@
+# Wall Minimum Reinforcement
+
+Minimum reinforcement for concrete walls to NS-EN 1992-1-1 with the Norwegian National
+Annex, and NS-EN 1992-3 for watertight walls. The point of the tool is not the arithmetic —
+it is making the **cost of each crack requirement visible**, so reinforcement is chosen
+rather than defaulted to.
+
+Live: <https://magnusfjeldolsen.github.io/structural_tools/concrete_wall_minimum_reinforcement/>
+
+## The idea
+
+For restraint cracking, 7.3.3(2) ties the permitted steel stress to the **bar diameter**
+through Table 7.2N, and that stress is the denominator of eq. (7.1). So the required area
+is a function of the bar you pick — small bars buy a high stress and need *less* steel:
+
+| ø | 8 | 10 | 12 | 16 | 20 | 25 |
+|---|---|---|---|---|---|---|
+| σs [MPa] | 391 | 354 | 316 | 258 | 228 | 202 |
+| As [mm²/m per face] | 1436 | 1583 | 1773 | 2178 | 2458 | 2779 |
+| max spacing | c35 | c50 | c64 | c92 | c128 | c177 |
+
+*(t = 350, B35, c = 35, wk = 0,30, kc = k = 1,0. The first three are arithmetically fine
+and unbuildable, which the tool says out loud.)*
+
+And the same wall under different requirements, at ø16:
+
+| requirement | As [mm²/m per face] |
+|---|---|
+| detailing only (NA.9.6.3) | 674 |
+| wk 0,40 | 1886 |
+| wk 0,30 | 2178 |
+| wk 0,20 | 2575 |
+| wk 0,30, cracking at 3 d | 1635 |
+| kc = 0,6 house rule | 1307 |
+
+## What it implements
+
+**Detailing, §9.6**
+- 9.6.2(1),(2): `As,vmin = 0,002·Ac`, half per face; `As,vmax = 0,04·Ac`
+- 9.6.2(3): vertical spacing ≤ min(3t, 400)
+- 9.6.3(2): horizontal spacing ≤ 400
+- 9.6.4: links trigger at 0,02·Ac, and the 4 links/m² rule with its ø ≤ 16 / cover > 2ø waiver
+- 9.6.1(1): scope warning at length/thickness < 4
+
+**NA.9.6.3** — `As,hmin = max(0,25·As,v ; k·Ac·fctm/fyk)`, k = 0,30 exterior / 0,15 interior,
+overridable. For a single central layer the code leg doubles, since 9.6.3(1) asks for the
+amount at each surface and one layer serves both.
+
+**Crack control, §7.3.2** — `As,min·σs = kc·k·fct,eff·Act`, with an absolute floor at
+`σs = fyk` that no crack-width relaxation can go below. Two routes, both computed always:
+
+- **7.3.3 simplified** — Table 7.2N with the eq. (7.7N) size adjustment, interpolated in
+  both σs and wk. Refuses rather than clamps when a bar falls off the table.
+- **7.3.4 direct** — full crack width from (7.8), (7.9) and (7.11) with `k2 = 1,0` for pure
+  tension, solved by bisection. Used automatically when wk falls outside Table 7.2N's
+  0,20–0,40 band, which is exactly the watertight case.
+
+**EN 1992-3** — Tightness Class 1 `wk1` interpolated on hD/h, eq. (7.122) bar adjustment,
+and Table L.1 restraint factors for the restrained-zone height.
+
+## The finding worth knowing about
+
+Note 1 to Table 7.2N states the table assumes **k2 = 0,5, kc = 0,4, hcr = 0,5h** — a section
+in **bending**. A wall cracking under edge restraint is in **uniform tension**, where
+k2 = 1,0 and hcr = h. Eq. (7.7N) rescales the bar size for that, but it does not restore k2
+inside `sr,max`. Checking the simplified answers against a direct 7.3.4 calculation shows
+they deliver wk ≈ 0,31–0,45 mm against a 0,30 mm target.
+
+7.3.1(9) makes the two routes alternatives, so both are code-compliant. The tool defaults
+to the simplified route because that is what Norwegian practice uses, shows the direct
+number on the adjacent row, and says plainly which is which.
+
+## Deliberately out of scope
+
+- Walls governed by out-of-plane bending — 9.6.1(1) sends those to the slab rules of §9.3,
+  so eq. (7.2) and a tension-zone `Act` are not implemented. Pairing `kc = 0,4` with
+  `Act = b·t` would double-count.
+- In-plane shear walls and coupling beams. That is a strength problem driven by analysis
+  forces, not a minimum-reinforcement problem.
+- Early-thermal modelling. The tool reports a restrained-zone height and a warning; it does
+  not compute T1.
+
+## Notes on inputs
+
+- **3 × t** is the default extent of the bottom zone. It is Norwegian practice, not an EC2
+  rule, and the tool labels it as such. Enter L and H to get the EN 1992-3 Table L.1 second
+  opinion, which keys off L/H rather than thickness and will flag long walls where 3t is
+  unconservative.
+- **Cover** is the cover to the horizontal bar. 9.6.3 puts those at the surface, and in a
+  wall they are normally the outer layer for exactly that reason.
+- **fctm** uses the closed form `0,30·fck^(2/3)`, not the rounded Table 3.1 value, so results
+  sit about 0,3 % above a hand check using fctm = 3,2 for B35.
+- Values taken from the Norwegian NA should be confirmed against your own copy of NA:2010.
+
+## Files
+
+| file | role |
+|---|---|
+| `wall_min_reinf_api.js` | pure calculation layer, no DOM, `module.exports` under Node for tests |
+| `script.js` | form reading and painting only |
+| `index.html` | single-screen UI |
+| `SPEC.md` | the contract the API implements, with its review log |
+| `print.css` | print layout |
+
+Verification vectors are listed in `SPEC.md` §11 and include the Statens vegvesen culvert
+example, a Norwegian retaining-wall report, and parity with the source spreadsheet.

--- a/concrete_wall_minimum_reinforcement/README.md
+++ b/concrete_wall_minimum_reinforcement/README.md
@@ -1,5 +1,10 @@
 # Wall Minimum Reinforcement
 
+> **Under development.** New tool, may contain errors. Written against the **Norwegian
+> National Annex** (NS-EN 1992-1-1:2004+A1:2014+NA:2018) — the NA values it applies are
+> Norwegian and will not be right in another country. Minimum reinforcement only. Check
+> every result independently before using it in a design.
+
 Minimum reinforcement for concrete walls to NS-EN 1992-1-1 with the Norwegian National
 Annex, and NS-EN 1992-3 for watertight walls. The point of the tool is not the arithmetic —
 it is making the **cost of each crack requirement visible**, so reinforcement is chosen

--- a/concrete_wall_minimum_reinforcement/README.md
+++ b/concrete_wall_minimum_reinforcement/README.md
@@ -35,16 +35,23 @@ And the same wall under different requirements, at ø16:
 
 ## What it implements
 
+All Norwegian NA values below were read from **NS-EN 1992-1-1:2004+A1:2014+NA:2018**
+directly, not from secondary sources.
+
 **Detailing, §9.6**
-- 9.6.2(1),(2): `As,vmin = 0,002·Ac`, half per face; `As,vmax = 0,04·Ac`
+- NA.9.6.2: `As,vmin = 0,002·Ac`, half per face; `As,vmax = 0,04·Ac`, which may be doubled at
+  lapped splices *only* where the laps sit at braced nodes — otherwise laps must be staggered
 - 9.6.2(3): vertical spacing ≤ min(3t, 400)
 - 9.6.3(2): horizontal spacing ≤ 400
 - 9.6.4: links trigger at 0,02·Ac, and the 4 links/m² rule with its ø ≤ 16 / cover > 2ø waiver
 - 9.6.1(1): scope warning at length/thickness < 4
 
-**NA.9.6.3** — `As,hmin = max(0,25·As,v ; k·Ac·fctm/fyk)`, k = 0,30 exterior / 0,15 interior,
-overridable. For a single central layer the code leg doubles, since 9.6.3(1) asks for the
-amount at each surface and one layer serves both.
+**NA.9.6.3(1)** — the minimum area **per face in doubly reinforced walls** is the greater of
+25 % of the vertical reinforcement *on the same side* and `k·Ac·fctm/fyk`, with k = 0,30 for
+exterior walls and 0,15 for interior. A **singly reinforced wall shall carry the
+corresponding total area** — so the single layer provides what the two faces would have
+provided between them, which works out as `max(0,25·As,v ; 2·k·Ac·fctm/fyk)` since its one
+layer already holds all the vertical steel.
 
 The two k values are worth understanding rather than accepting. EC2's own recommendation is
 a flat `As,hmin = 0,001·Ac`. The Norwegian NA replaces it with a strength-dependent form,
@@ -61,6 +68,38 @@ So 0,15 is not a halving of 0,30 — it *is* the EC2 baseline, re-expressed so t
 scales with the force that cracks the section. 0,30 is a deliberate doubling for walls
 exposed to outdoor climate, where the imposed strain is roughly twice as large. Anything
 weather-exposed or cast against soil is normally taken as exterior.
+
+**Tightness — the NA's own rules, not options.** Where tightness governs (EN 1992-3),
+NA.9.6.2 requires the vertical minimum to be **at least double**, so `0,004·Ac`; and
+NA.9.6.3(1) requires the horizontal minimum to come from eq. (7.1) with
+**`fct,eff = fctm`** (28 days) and **`k = kc = 1,0`**. In the watertight mode the tool applies
+all three and locks the kc, k and cracking-age inputs, because they are no longer the
+designer's to choose.
+
+**NA.7.3.4(3)** — `k3 = 3,4`, `k4 = 0,425`, and `Ac,eff` not less than that corresponding to
+`hc,eff = (h − d + 1,5ø)`. That floor is a relaxation and it binds mainly on single-layer
+walls, where the EC2 `h/2` cap would otherwise be the smaller of the two.
+
+**NA.7.3.1(5)** — `wmax` from Table NA.7.1N with `kc = cnom/cmin,dur ≤ 1,3` (eq. NA.901).
+Footnote 1 to that table is what licenses the "no crack control required" option: in X0 the
+crack width does not affect durability, the 0,40 limit is there for appearance, and where
+appearance is not a constraint the value may be increased.
+
+**Tightness — the NA's own rules, not options.** Where tightness governs (EN 1992-3),
+NA.9.6.2 requires the vertical minimum to be **at least double**, so `0,004·Ac`; and
+NA.9.6.3(1) requires the horizontal minimum to come from eq. (7.1) with
+**`fct,eff = fctm`** (28 days) and **`k = kc = 1,0`**. In the watertight mode the tool applies
+all three and locks the kc, k and cracking-age inputs, because they are no longer the
+designer's to choose.
+
+**NA.7.3.4(3)** — `k3 = 3,4`, `k4 = 0,425`, and `Ac,eff` not less than that corresponding to
+`hc,eff = (h − d + 1,5ø)`. That floor is a relaxation and it binds mainly on single-layer
+walls, where the EC2 `h/2` cap would otherwise be the smaller of the two.
+
+**NA.7.3.1(5)** — `wmax` from Table NA.7.1N with `kc = cnom/cmin,dur ≤ 1,3` (eq. NA.901).
+Footnote 1 to that table is what licenses the "no crack control required" option: in X0 the
+crack width does not affect durability, the 0,40 limit is there for appearance, and where
+appearance is not a constraint the value may be increased.
 
 **Crack control, §7.3.2** — `As,min·σs = kc·k·fct,eff·Act`, with an absolute floor at
 `σs = fyk` that no crack-width relaxation can go below. Two routes, both computed always:
@@ -110,7 +149,8 @@ number on the adjacent row, and says plainly which is which.
   §7.3.2 active the crack requirement normally sits well above both legs, and the choice
   stops mattering — for t = 400, B35, ø12 it is c145 against c290 with no crack control,
   and c60 either way at wk 0,30.
-- Values taken from the Norwegian NA should be confirmed against your own copy of NA:2010.
+- The NA does **not** amend 7.3.2(2), so `kc`, `k`, `fct,eff` and `Act` are the EC2 values
+  outside the tightness case.
 
 ## Files
 

--- a/concrete_wall_minimum_reinforcement/SPEC.md
+++ b/concrete_wall_minimum_reinforcement/SPEC.md
@@ -1,0 +1,288 @@
+# Build spec — `concrete_wall_minimum_reinforcement`
+
+Contract for `wall_min_reinf_api.js`. Pure functions, no DOM. Units: mm, N, MPa, mm²/m
+per metre of wall, unless stated. Revision 2 — see the review log at the end for what
+changed and why.
+
+## 1. Inputs
+
+```js
+{
+  mode: 'ordinary' | 'onBase' | 'watertight',
+  restrainedTopBottom: boolean,
+
+  t: 350,                 // wall thickness [mm]
+  fck: 35,                // [MPa]
+  fyk: 500,               // [MPa]
+  layers: 2,              // 1 = single central layer, 2 = one layer per face
+  cover: 35,              // cover to the HORIZONTAL bar [mm] — see §6 note
+  exposureSide: 'exterior' | 'interior',   // NA.9.6.3 k = 0,30 / 0,15
+  kNaOverride: null | number,
+
+  vBar: { dia: 12, spacing: 250 },   // provided vertical steel per layer
+
+  crackReq: 'none' | 'wk040' | 'wk030' | 'wk020' | 'watertight' | 'custom',
+  wkCustom: null | number,
+  naCoverUplift: { on: false, cnom: 35, cminDur: 25 },
+  hD: 2000,               // hydrostatic head [mm], watertight only
+
+  kcMode: 'pureTension' | 'house' | 'custom',   // 1,0 / 0,6 / free
+  kcCustom: null | number,
+  kMode: 'external' | 'ec2h',                   // 1,0 / interpolate on t
+  crackAgeDays: 28,
+  cementClass: 'N' | 'R' | 'S',
+  method: 'simplified' | 'direct',              // which route drives the matrix colours
+  selectedDia: 16,                              // which bar the headline numbers report
+
+  wallL: null, wallH: null,                     // [mm], enables the Table L.1 opinion
+  epsFree: 320e-6, epsCtu: 100e-6
+}
+```
+
+Both routes (§6 and §7) are always computed. `method` only decides which one colours the
+ø × cc matrix and drives the headline.
+
+## 2. Material
+
+```
+fctm(fck)   = 0,30·fck^(2/3)                for fck ≤ 50
+            = 2,12·ln(1 + (fck+8)/10)       for fck > 50           [EC2 Table 3.1]
+βcc(t)      = exp( s·(1 − √(28/t)) )        s = 0,20 R / 0,25 N / 0,38 S   [3.2]
+fctm(t)     = βcc(t)^α · fctm               α = 1 for t < 28 d             [3.4]
+fct,eff     = fctm(crackAgeDays)                                           [7.3.2(2)]
+Ecm         = 22 000·((fck+8)/10)^0,3                                      [Table 3.1]
+Es          = 200 000
+```
+
+`fctm` (28-day) drives the **NA.9.6.3 detailing rule**. `fct,eff` drives **eq. (7.1)**
+only. Never substitute one for the other.
+
+When `crackAgeDays < 28`, emit a warning: EC2 permits `fctm(t)`, but several National
+Annexes impose a floor on `fct,eff` for early-age restraint. The user must confirm
+against NA:2010. No floor is applied silently.
+
+## 3. Detailing requirements
+
+```
+Ac        = 1000·t                                        [mm²/m]
+As_v_min  = 0,002·Ac / layers                             per layer   [9.6.2(1),(2)]
+As_v_max  = 0,04·Ac                (0,08·Ac at laps)                  [9.6.2(1)]
+s_v_max   = min(3t, 400)                                              [9.6.2(3)]
+s_h_max   = 400                                                       [9.6.3(2)]
+
+As_v_prov = 1000/vBar.spacing · π·vBar.dia²/4             per layer
+k_NA      = kNaOverride ?? (exterior ? 0,30 : 0,15)
+As_h_surf = max( 0,25·As_v_prov , k_NA·Ac·fctm/fyk )      per surface [NA.9.6.3]
+As_h_min  = layers === 2 ? As_h_surf
+                         : max( 0,25·As_v_prov , 2·k_NA·Ac·fctm/fyk )
+```
+
+The `layers === 1` branch is the subtle one. 9.6.3(1) asks for `As,hmin` **at each
+surface**, and a single central layer has to serve both — so the code leg doubles. The
+25 % leg does not, because with one layer `As_v_prov` is already the whole-section
+vertical steel and 25 % of it is the whole-section answer. This reproduces the source
+spreadsheet's `J10 = 2·C7`.
+
+```
+links required if As_v_prov·layers > 0,02·Ac                          [9.6.4(1)]
+4 links/m² unless (dia ≤ 16 and cover > 2·dia); n/a for layers = 1    [9.6.4(2)]
+```
+
+## 4. Crack requirement → target `wk`
+
+| `crackReq` | wk |
+|---|---|
+| `none` | — (7.3.2 switched off) |
+| `wk040` | 0,40 |
+| `wk030` | 0,30, × NA uplift if on |
+| `wk020` | 0,20 |
+| `watertight` | EN 1992-3 `wk1`: 0,2 at hD/t ≤ 5, 0,05 at hD/t ≥ 35, linear between |
+| `custom` | `wkCustom` |
+
+NA uplift: `kc_cover = clamp(cnom/cminDur, 1,0, 1,3)`, `wk = 0,30·kc_cover`.
+
+## 5. eq. (7.1) coefficients
+
+```
+kc  = 1,0 (pureTension) | 0,6 (house) | kcCustom
+k   = 1,0 (external)  |  ec2h: 1,0 for t ≤ 300, 0,65 for t ≥ 800, linear between
+Act = Ac = 1000·t                       full section in tension (restraint)
+As_min_total = kc·k·fct,eff·Act / σs
+As_min_layer = As_min_total / layers
+```
+
+**Absolute floor**, independent of `wk` and of the route taken:
+
+```
+As_floor = kc·k·fct,eff·Act / (fyk·layers)
+```
+
+No amount of crack-width relaxation permits less than this — below it the steel yields at
+first cracking. Both routes clamp to it and flag when it governs.
+
+Out of scope for v1: walls governed by out-of-plane bending. 9.6.1(1) sends those to the
+slab rules (§9.3), so eq. (7.2) and a tension-zone `Act` are deliberately not
+implemented — pairing `kc = 0,4` with `Act = b·t` would double-count.
+
+## 6. Simplified route (7.3.3(2) + Table 7.2N)
+
+Table 7.2N, `φ*s` [mm]; `null` = no value:
+
+```
+σs :  160  200  240  280  320  360  400  450
+0,4:   40   32   20   16   12   10    8    6
+0,3:   32   25   16   12   10    8    6    5
+0,2:   25   16   12    8    6    5    4  null
+```
+
+Interpolation is two-dimensional: linear in `wk` between columns (EN 1992-3 §7.3.3 permits
+interpolation for intermediate crack widths), then inverted in `σs`. Rows where either
+bracketing column is `null` are dropped before inversion. Valid only for
+`0,20 ≤ wk ≤ 0,40`; outside that band the simplified route refuses and the direct route
+of §7 is the only answer.
+
+Per bar diameter `d`:
+
+```
+h_minus_d = layers === 2 ? cover + d/2 : t/2       [7.3.3(2), all-tension case]
+denom     = (mode === 'watertight') ? 10 : 8       [eq. 7.122 vs eq. 7.7N]
+f_adj     = (fct,eff/2,9) · t / (denom·h_minus_d)  hcr = t, section fully in tension
+φ*_req    = d / f_adj
+σs        = invert Table 7.2N at wk for φ*_req
+As_req    = max( kc·k·fct,eff·Act/(σs·layers), As_floor )
+cc_max    = 1000·(π·d²/4) / As_req
+```
+
+Inversion outcomes, and none of them may be a silent clamp:
+
+- `φ*_req` **larger** than the σs = 160 entry → `status: 'outOfTable'`, no number. This is
+  the direction that matters: pinning σs at 160 would understate the requirement.
+- `φ*_req` **smaller** than the last entry → σs capped at `min(450, fyk)`,
+  `status: 'capped'`. Conservative, so a number is returned, but it is labelled.
+- otherwise `status: 'ok'`.
+
+Note on `cover`: 9.6.3 puts the horizontal bars at the surface, and in a wall they are
+normally the **outer** layer for exactly this reason. `cover` is therefore the cover to
+the horizontal bar, i.e. `cnom`. The vertical bars sit inside them at `cnom + d_h`, which
+does not enter any calculation here because the vertical direction is detailing-driven.
+
+Note on `denom = 10` for watertight: EN 1992-3 eq. (7.122) uses 10 and draws `φ*s` from
+Figure 7.103N rather than Table 7.2N. Table 7.2N is used here as a stand-in over
+`0,20 ≤ wk ≤ 0,40`, where the two agree; below 0,20 only the direct route is offered.
+
+## 7. Direct route (7.3.4)
+
+For a section fully in tension, per layer, given `As`:
+
+```
+σs        = min( kc·k·fct,eff·Act / (As·layers), fyk )
+c_eff     = layers === 2 ? cover : (t − d)/2
+h_c,ef    = min( 2,5·(h_minus_d), t/2 )                 [7.3.2(3), Fig. 7.1c]
+Ac,eff    = 1000·h_c,ef
+ρ_p,eff   = As / Ac,eff
+αe        = Es/Ecm
+sr,max    = 3,4·c_eff + 0,8·1,0·0,425·d / ρ_p,eff       k1 0,8  k2 1,0 (tension)  [7.11]
+εsm−εcm   = max( (σs − 0,4·fct,eff/ρ_p,eff·(1+αe·ρ_p,eff))/Es , 0,6·σs/Es )  kt 0,4 [7.9]
+wk        = sr,max·(εsm−εcm)                                                       [7.8]
+```
+
+`wk` is monotonically decreasing in `As`, so solve `wk(As) = wk_target` by bisection on
+`As ∈ [As_floor, 20000]` mm²/m, 60 iterations. If `wk(As_floor) ≤ wk_target` the floor
+governs. If `wk(20000) > wk_target` the target is unreachable — report `'unreachable'`,
+do not return 20000.
+
+(7.11) is valid while `s ≤ 5(c_eff + d/2)`; flag when the resulting `cc_max` exceeds it,
+since (7.14) rather than (7.11) then governs the crack spacing.
+
+## 8. Buildability
+
+A required spacing is not an answer if nobody can fix the bars.
+
+```
+cc_max < 75           → 'unbuildable'
+75 ≤ cc_max < 100     → 'tight'
+cc_max > s_h_max      → capped at s_h_max (the detailing rule wins)
+```
+
+Also `cc_max ≥ 2d` and `≥ 20 mm` per 8.2 clear-distance, which the 75 mm floor already
+covers for every bar in the list.
+
+## 9. Restrained zone height
+
+```
+zone_practice = 3·t                       default, labelled "practice (NO), not EC2"
+
+EN 1992-3 Table L.1, wall on base:
+  L/H :   ≤1     2     3     4    ≥8
+  R_top:   0     0   0,05  0,3   0,5      R_base = 0,5 always, linear in between
+R_crit  = epsCtu / epsFree
+  R_crit ≥ 0,5      → no restraint cracking predicted anywhere; report it
+  R_top  ≥ R_crit   → full height
+  else              → z = H·(0,5 − R_crit)/(0,5 − R_top)
+```
+
+## 10. Outputs
+
+```js
+{
+  ok: true,
+  material: { fctm, fctEff, Ecm, betaCc, alphaE },
+  detailing: { AsVMin, AsVMax, sVMax, AsVProv, kNA, AsHMin, sHMax, links: {...} },
+  crack: { active, wk, wkSource, kc, k, Act, AsFloor,
+           bars:       [ { dia, phiStarReq, sigmaS, AsReq, ccMax, status, build } ],
+           barsDirect: [ { dia, sigmaS, AsReq, ccMax, status, build, srMax } ] },
+  governing: { horizontal: { As, clause, dia, ccMax }, vertical: { As, clause } },
+  zone: { practice, tableL1: { LH, Rtop, Rcrit, height, note } | null },
+  checks: [ { id, label, status: 'ok'|'warn'|'fail'|'info', detail } ],
+  warnings: [ ... ]
+}
+```
+
+`governing.horizontal` is reported for `selectedDia`, because the required area is a
+function of the bar — that is the whole point of the tool. The full `bars` array is
+always returned so the UI can show every diameter at once.
+
+## 11. Test vectors
+
+| case | expectation |
+|---|---|
+| t 350, B35, exterior, ø12 c250 | `fctm` 3,21; `AsHMin` 672; `AsVMin` 350 |
+| same, kc 1,0, σs forced 240 | `As_min_layer` 2333 |
+| t 350, B35, wk 0,3, ø16, c 35, 2 layers | φ*_req 14,25; σs ≈ 257; As ≈ 2175; cc ≈ 92 |
+| t 240, B45, exterior, As_v 480 total | `AsHMin` 547 |
+| t 400, fctm 3,2, exterior | `k_NA·Ac·fctm/fyk` = 768 |
+| t 200, single layer, wk 0,3, ø8 | φ*_req ≈ 29 → `outOfTable` |
+| t 100 | `sVMax` 300 |
+| fck 40 | `fctm` 3,51 (not 0 — the source sheet's SUMIF trap) |
+| fck 35, 3 d, CEM N | `fctEff` ≈ 1,92 |
+| L/H 12 | `R_top` 0,5, full height |
+| L 6000 H 3000, εfree 320µ, εctu 100µ | z ≈ 1140 mm vs 3t = 1050 mm |
+| any input, kc 1,0, B35, t 350, layers 2 | `AsFloor` = 1120 mm²/m per layer |
+
+---
+
+## Review log — what revision 1 got wrong
+
+1. **Single-layer `As_h_min` was contradictory.** The prose said it doubles, the formula
+   did not. Worse, doubling the 25 % leg as well would have been wrong, because with one
+   layer `As_v_prov` is already the whole-section vertical. Split the two legs. (§3)
+2. **No absolute floor.** Nothing stopped a lax `wk` from returning an area at which the
+   steel yields the instant the section cracks. Added `As_floor = kc·k·fct,eff·Act/fyk`,
+   binding on both routes. (§5)
+3. **Silent clamping in both directions.** Revision 1 clamped σs to [160, 450] and
+   returned a number either way. The low end is unconservative and must refuse; the high
+   end is conservative and may return, but labelled. Split into `outOfTable` / `capped`. (§6)
+4. **The watertight factor was dropped.** Revision 1 used `/8` everywhere. EN 1992-3
+   eq. (7.122) uses `/10`, which is *more* onerous, so using `/8` for a tank would have
+   under-reinforced it. (§6)
+5. **`cover` was undefined for the direct route with a single central layer.** `c` in
+   (7.11) is cover to the bar surface, which for a central bar is `(t − d)/2`, not the
+   nominal cover to a face. (§7)
+6. **Bisection could return its own upper bound.** With no reachability test, an
+   impossible `wk` would have silently returned 20000 mm²/m as if it were an answer. (§7)
+7. **No buildability filter.** `cc_max = 32 mm` is arithmetically correct and useless.
+   Added the unbuildable/tight bands. (§8)
+8. **`R_crit ≥ 0,5` was unhandled** — the case where the wall simply does not crack, which
+   is the answer the user most wants to hear when it is true. (§9)
+9. **`governing` was a scalar.** Since `As_req` is a function of the bar diameter, a
+   single governing number is meaningless without saying which bar it belongs to. (§10)

--- a/concrete_wall_minimum_reinforcement/SPEC.md
+++ b/concrete_wall_minimum_reinforcement/SPEC.md
@@ -1,8 +1,9 @@
 # Build spec — `concrete_wall_minimum_reinforcement`
 
 Contract for `wall_min_reinf_api.js`. Pure functions, no DOM. Units: mm, N, MPa, mm²/m
-per metre of wall, unless stated. Revision 2 — see the review log at the end for what
-changed and why.
+per metre of wall, unless stated. Revision 3 — see the review log at the end for what
+changed and why. All National Annex values are from **NS-EN 1992-1-1:2004+A1:2014+NA:2018**,
+read from the standard.
 
 ## 1. Inputs
 
@@ -58,15 +59,22 @@ Es          = 200 000
 only. Never substitute one for the other.
 
 When `crackAgeDays < 28`, emit a warning: EC2 permits `fctm(t)`, but several National
-Annexes impose a floor on `fct,eff` for early-age restraint. The user must confirm
-against NA:2010. No floor is applied silently.
+Annexes impose a floor on `fct,eff` for early-age restraint. NA:2018 imposes none for
+reinforced concrete — it amends only 7.3.2(4), which concerns σct,p in prestressed
+members — so no floor is applied. `crackAgeDays` is ignored entirely under `tightness`
+(see §5).
 
 ## 3. Detailing requirements
 
+`tightness = (mode === 'watertight')` — NA.9.6.2 and NA.9.6.3(1) both attach extra
+requirements to a wall where tightness governs, and they are requirements, not options.
+
 ```
 Ac        = 1000·t                                        [mm²/m]
-As_v_min  = 0,002·Ac / layers                             per layer   [9.6.2(1),(2)]
-As_v_max  = 0,04·Ac                (0,08·Ac at laps)                  [9.6.2(1)]
+As_v_min  = (tightness ? 0,004 : 0,002)·Ac / layers       per layer   [NA.9.6.2]
+As_v_max  = 0,04·Ac                                                   [NA.9.6.2]
+            may be doubled at lapped splices ONLY where the laps sit at
+            braced nodes; otherwise laps must be staggered
 s_v_max   = min(3t, 400)                                              [9.6.2(3)]
 s_h_max   = 400                                                       [9.6.3(2)]
 
@@ -77,10 +85,11 @@ As_h_min  = layers === 2 ? As_h_surf
                          : max( 0,25·As_v_prov , 2·k_NA·Ac·fctm/fyk )
 ```
 
-The `layers === 1` branch is the subtle one. 9.6.3(1) asks for `As,hmin` **at each
-surface**, and a single central layer has to serve both — so the code leg doubles. The
-25 % leg does not, because with one layer `As_v_prov` is already the whole-section
-vertical steel and 25 % of it is the whole-section answer. This reproduces the source
+The `layers === 1` branch is the subtle one, and NA.9.6.3(1) settles it: the tabulated
+minimum is *per face in doubly reinforced walls*, and a singly reinforced wall shall carry
+**the corresponding total area**. Doubling the section total means doubling the code leg,
+while the 25 % leg is already whole-section because a single layer holds all the vertical
+steel. Hence `max(0,25·As_v_prov, 2·k_NA·Ac·fctm/fyk)`, which also reproduces the source
 spreadsheet's `J10 = 2·C7`.
 
 ```
@@ -103,8 +112,11 @@ NA uplift: `kc_cover = clamp(cnom/cminDur, 1,0, 1,3)`, `wk = 0,30·kc_cover`.
 
 ## 5. eq. (7.1) coefficients
 
+Under `tightness`, NA.9.6.3(1) fixes all three of these and the corresponding inputs are
+ignored: `kc = 1,0`, `k = 1,0`, `fct,eff = fctm` at 28 days.
+
 ```
-kc  = 1,0 (pureTension) | 0,6 (house) | kcCustom
+kc  = 1,0 (pureTension) | 0,6 (house) | kcCustom          overridden by tightness
 k   = 1,0 (external)  |  ec2h: 1,0 for t ≤ 300, 0,65 for t ≥ 800, linear between
 Act = Ac = 1000·t                       full section in tension (restraint)
 As_min_total = kc·k·fct,eff·Act / σs
@@ -177,7 +189,11 @@ For a section fully in tension, per layer, given `As`:
 ```
 σs        = min( kc·k·fct,eff·Act / (As·layers), fyk )
 c_eff     = layers === 2 ? cover : (t − d)/2
-h_c,ef    = min( 2,5·(h_minus_d), t/2 )                 [7.3.2(3), Fig. 7.1c]
+h_c,ef    = max( min(2,5·(h_minus_d), t/2),
+                 min(h_minus_d + 1,5·d, t/layers) )      [7.3.2(3) + NA.7.3.4(3)]
+            NA.7.3.4(3) floors Ac,eff at hc,eff = (h - d + 1,5ø); the inner
+            min keeps it within the half-section of Fig. 7.1(c) so two faces
+            cannot claim the same concrete
 Ac,eff    = 1000·h_c,ef
 ρ_p,eff   = As / Ac,eff
 αe        = Es/Ecm
@@ -256,7 +272,10 @@ always returned so the UI can show every diameter at once.
 | fck 40 | `fctm` 3,51 (not 0 — the source sheet's SUMIF trap) |
 | fck 35, 3 d, CEM N | `fctEff` ≈ 1,92 |
 | L/H 12 | `R_top` 0,5, full height |
-| L 6000 H 3000, εfree 320µ, εctu 100µ | z ≈ 1140 mm vs 3t = 1050 mm |
+| L 6000 H 3000, εfree 320µ, εctu 100µ | z ≈ 1125 mm vs 3t = 1050 mm |
+| watertight, t 300 | `AsVMin` 600 per face (doubled), `kc` = `k` = 1,0, `fct,eff` = fctm |
+| watertight with crackAgeDays 3 and kcMode house | both ignored; same result as above |
+| t 200, 1 layer, ø8 | NA `hc,eff` floor 112 mm governs over the EC2 100 mm |
 | any input, kc 1,0, B35, t 350, layers 2 | `AsFloor` = 1120 mm²/m per layer |
 
 ---
@@ -286,3 +305,22 @@ always returned so the UI can show every diameter at once.
    is the answer the user most wants to hear when it is true. (§9)
 9. **`governing` was a scalar.** Since `As_req` is a function of the bar diameter, a
    single governing number is meaningless without saying which bar it belongs to. (§10)
+
+---
+
+## Revision 3 — what reading NA:2018 changed
+
+The module was built from secondary sources for the National Annex values. Reading
+NS-EN 1992-1-1:2004+A1:2014+NA:2018 confirmed NA.9.6.3(1), NA.9.6.2, NA.7.3.1(5) with
+Table NA.7.1N and eq. (NA.901), and that the NA amends only 7.3.2(4) — and turned up four
+things that were missing:
+
+1. `As,vmin` doubles to `0,004·Ac` where tightness governs (NA.9.6.2).
+2. Where tightness governs, eq. (7.1) must use `fct,eff = fctm` and `k = kc = 1,0`
+   (NA.9.6.3(1)). The early-age reduction and the 0,6 house rule are not available there.
+3. `Ac,eff` has a floor at `hc,eff = (h − d + 1,5ø)` (NA.7.3.4(3)).
+4. `As,vmax` doubles at laps only where the laps sit at braced nodes (NA.9.6.2).
+
+Footnote 1 to Table NA.7.1N is also the clause behind the "no crack control required"
+option: in X0 the crack width does not affect durability, the 0,40 limit is for
+appearance, and it may be increased where appearance is not a constraint.

--- a/concrete_wall_minimum_reinforcement/index.html
+++ b/concrete_wall_minimum_reinforcement/index.html
@@ -89,6 +89,18 @@
     <a href="../index.html" class="text-sky-400 hover:text-sky-300 text-sm">← Back to tools</a>
   </div>
 
+  <div class="mb-3 p-3 rounded-lg" style="background:rgba(234,179,8,.09);border:1px solid rgba(234,179,8,.28)">
+    <p class="text-amber-300 text-sm font-medium mb-1">
+      &#9888;&#65039; Under development &mdash; this tool is new and may contain errors.
+    </p>
+    <p class="text-amber-200/70 text-xs leading-relaxed">
+      Written against the <b>Norwegian National Annex</b>, NS-EN 1992-1-1:2004+A1:2014+NA:2018, so the
+      values it applies for NA.9.6.2, NA.9.6.3, NA.7.3.1(5) and NA.7.3.4(3) are Norwegian and will not
+      be right in another country. It covers minimum reinforcement only, not bending, shear or in-plane
+      forces. Check every result independently before using it in a design.
+    </p>
+  </div>
+
   <!-- ============ INPUTS ============ -->
   <div class="panel p-3 mb-3">
 

--- a/concrete_wall_minimum_reinforcement/index.html
+++ b/concrete_wall_minimum_reinforcement/index.html
@@ -47,7 +47,8 @@
     .pill.on { background:#0ea5e9; border-color:#0ea5e9; color:#04121f; font-weight:600; }
     .pill.sm { padding:.18rem .45rem; font-size:.74rem; }
     table.grid { border-collapse:separate; border-spacing:2px; font-variant-numeric:tabular-nums; }
-    table.grid th, table.grid td { padding:.28rem .4rem; font-size:.78rem; text-align:right; border-radius:.25rem; }
+    table.grid th, table.grid td { padding:.28rem .4rem; font-size:.78rem; text-align:right;
+                                  border-radius:.25rem; white-space:nowrap; }
     table.grid th { color:#7f92ad; font-weight:600; }
     .c-ok   { background:#064e3b; color:#6ee7b7; }
     .c-near { background:#4d3908; color:#fcd34d; }
@@ -63,6 +64,16 @@
     details > summary::-webkit-details-marker { display:none; }
     .barbg { background:#1c2537; border-radius:2px; height:8px; overflow:hidden; }
     .barfg { height:100%; border-radius:2px; }
+    #tip { position:fixed; z-index:60; max-width:22rem; background:#0d1526; border:1px solid #33496b;
+           border-radius:.4rem; padding:.5rem .6rem; box-shadow:0 10px 30px rgba(0,0,0,.6);
+           font-size:.75rem; line-height:1.45; color:#bccbdf; pointer-events:none;
+           opacity:0; transition:opacity .1s; }
+    #tip.on { opacity:1; }
+    #tip b { display:block; color:#e6edf6; font-size:.78rem; margin-bottom:.25rem; }
+    #tip em { color:#7dd3fc; font-style:normal; }
+    .lbl[data-tip] { text-decoration:underline dotted #44607f; text-underline-offset:3px; cursor:help; }
+    .tiphint { font-size:.68rem; color:#5c6b82; }
+    @media (max-width:1280px){ .herosplit { grid-template-columns:1fr !important; } }
     @media (max-width:900px){ .twocol { grid-template-columns:1fr !important; } }
   </style>
 </head>
@@ -90,6 +101,7 @@
         <input type="checkbox" id="rtb" class="accent-sky-500"> also restrained top and bottom
       </label>
       <span id="modeHint" class="text-xs text-slate-500 ml-auto"></span>
+      <span class="tiphint w-full">Hover any control to see what it changes in the calculation.</span>
     </div>
 
     <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2 mb-3">
@@ -106,7 +118,7 @@
       <div><span class="lbl">Wall side</span>
         <select id="side" class="fld"><option value="exterior" selected>Exterior (yttervegg)</option><option value="interior">Interior (innervegg)</option></select></div>
       <div><span class="lbl">Vert. bar ø</span>
-        <select id="vdia" class="fld"><option>8</option><option>10</option><option selected>12</option><option>16</option><option>20</option><option>25</option></select></div>
+        <select id="vdia" class="fld"><option>8</option><option>10</option><option selected>12</option><option>16</option><option>20</option><option>25</option><option>32</option></select></div>
       <div><span class="lbl">Vert. bar cc</span><input id="vcc" class="fld" value="250"></div>
     </div>
 
@@ -189,15 +201,25 @@
     <div class="space-y-3">
       <div class="panel p-3">
         <div class="flex items-baseline justify-between mb-2">
-          <span class="lbl mb-0">Required area and spacing, per bar size · each face</span>
+          <span class="lbl mb-0">Required area and spacing, per bar size</span>
           <div class="flex items-center gap-1">
             <span class="text-xs text-slate-500 mr-1">click a column to select</span>
             <button class="pill sm on" data-method="simplified">7.3.3 simplified</button>
             <button class="pill sm" data-method="direct">7.3.4 direct</button>
           </div>
         </div>
-        <div class="overflow-x-auto"><table class="grid w-full" id="heroTable"></table></div>
-        <div id="heroNote" class="text-xs text-slate-500 mt-2"></div>
+        <div class="grid gap-4 herosplit" style="grid-template-columns:1.15fr 1fr">
+          <div>
+            <div class="lbl">Horizontal · each face</div>
+            <div class="overflow-x-auto"><table class="grid w-full" id="heroTable"></table></div>
+            <div id="heroNote" class="text-xs text-slate-500 mt-2"></div>
+          </div>
+          <div>
+            <div class="lbl">Vertical · each face</div>
+            <div class="overflow-x-auto"><table class="grid w-full" id="vertTable"></table></div>
+            <div id="vertNote" class="text-xs text-slate-500 mt-2"></div>
+          </div>
+        </div>
       </div>
 
       <div class="panel p-3">
@@ -231,6 +253,8 @@
     National Annex should be confirmed against your own copy of NA:2010. Always check results independently.
   </p>
 </div>
+
+<div id="tip" role="tooltip"></div>
 
 <script src="wall_min_reinf_api.js"></script>
 <script src="script.js"></script>

--- a/concrete_wall_minimum_reinforcement/index.html
+++ b/concrete_wall_minimum_reinforcement/index.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BFVZQQ2LYN"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BFVZQQ2LYN');
+  </script>
+
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wall Minimum Reinforcement Calculator | Eurocode 2 + Norwegian NA</title>
+  <meta name="description" content="Minimum reinforcement for concrete walls to EC2 and the Norwegian National Annex. Vertical and horizontal minima to 9.6.2 and NA.9.6.3, restraint crack control to 7.3.2 with Table 7.2N and direct calculation to 7.3.4, watertight walls to EN 1992-3, and a bar-by-bar spacing matrix showing what each crack requirement actually costs.">
+  <meta name="keywords" content="minimum reinforcement wall, minimumsarmering vegg, EC2 9.6.2, NA.9.6.3, 7.3.2 crack control, restraint cracking, edge restraint, yttervegg, innervegg, vanntett vegg, heisgrube, Table 7.2N, EN 1992-3, basement wall reinforcement, retaining wall minimum reinforcement">
+  <meta name="author" content="Magnus Fjeld Olsen">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://magnusfjeldolsen.github.io/structural_tools/concrete_wall_minimum_reinforcement/">
+
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://magnusfjeldolsen.github.io/structural_tools/concrete_wall_minimum_reinforcement/">
+  <meta property="og:title" content="Wall Minimum Reinforcement Calculator">
+  <meta property="og:description" content="Minimum reinforcement for concrete walls to EC2 + Norwegian NA, showing what each crack requirement actually costs in steel.">
+  <meta property="og:site_name" content="Structural Engineering Tools">
+
+  <link rel="stylesheet" href="../assets/css/common.css">
+  <link rel="stylesheet" href="../assets/css/forms.css">
+  <link rel="stylesheet" href="../assets/css/components.css">
+  <link rel="stylesheet" href="print.css" media="print">
+
+  <script>tailwind = window.tailwind || {}; tailwind.config = { darkMode: 'class' };</script>
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <style>
+    body { background:#0b1120; }
+    .panel { background:#131c2e; border:1px solid #22304a; border-radius:.6rem; }
+    .lbl { font-size:.68rem; letter-spacing:.04em; text-transform:uppercase; color:#7f92ad; display:block; margin-bottom:.2rem; }
+    .fld { width:100%; background:#0b1120; border:1px solid #2c3d5a; border-radius:.35rem;
+           padding:.3rem .45rem; color:#e6edf6; font-size:.86rem; font-variant-numeric:tabular-nums; }
+    .fld:focus { outline:none; border-color:#38bdf8; box-shadow:0 0 0 2px rgba(56,189,248,.2); }
+    .pill { padding:.28rem .6rem; border-radius:.35rem; font-size:.8rem; border:1px solid #2c3d5a;
+            background:#0b1120; color:#a8b8cd; cursor:pointer; white-space:nowrap; }
+    .pill:hover { border-color:#44607f; color:#d8e4f2; }
+    .pill.on { background:#0ea5e9; border-color:#0ea5e9; color:#04121f; font-weight:600; }
+    .pill.sm { padding:.18rem .45rem; font-size:.74rem; }
+    table.grid { border-collapse:separate; border-spacing:2px; font-variant-numeric:tabular-nums; }
+    table.grid th, table.grid td { padding:.28rem .4rem; font-size:.78rem; text-align:right; border-radius:.25rem; }
+    table.grid th { color:#7f92ad; font-weight:600; }
+    .c-ok   { background:#064e3b; color:#6ee7b7; }
+    .c-near { background:#4d3908; color:#fcd34d; }
+    .c-bad  { background:#4c1023; color:#fda4af; }
+    .c-cap  { background:#1c2537; color:#5c6b82; }
+    .c-veto { background:#1c2537; color:#5c6b82;
+              background-image:repeating-linear-gradient(45deg,transparent,transparent 3px,#334155 3px,#334155 4px); }
+    .c-pick { outline:2px solid #38bdf8; outline-offset:-2px; }
+    .num { font-variant-numeric:tabular-nums; }
+    .chk-ok   { color:#34d399; } .chk-warn { color:#fbbf24; }
+    .chk-fail { color:#fb7185; } .chk-info { color:#7f92ad; }
+    details > summary { cursor:pointer; list-style:none; }
+    details > summary::-webkit-details-marker { display:none; }
+    .barbg { background:#1c2537; border-radius:2px; height:8px; overflow:hidden; }
+    .barfg { height:100%; border-radius:2px; }
+    @media (max-width:900px){ .twocol { grid-template-columns:1fr !important; } }
+  </style>
+</head>
+<body class="text-gray-100 min-h-screen">
+
+<div class="max-w-[1400px] mx-auto px-3 py-4">
+
+  <div class="flex items-baseline justify-between mb-3">
+    <div>
+      <h1 class="text-xl font-semibold text-white">Wall Minimum Reinforcement</h1>
+      <p class="text-xs text-slate-400">NS-EN 1992-1-1 §9.6 + NA.9.6.3 · §7.3.2 crack control · EN 1992-3 for watertight walls</p>
+    </div>
+    <a href="../index.html" class="text-sky-400 hover:text-sky-300 text-sm">← Back to tools</a>
+  </div>
+
+  <!-- ============ INPUTS ============ -->
+  <div class="panel p-3 mb-3">
+
+    <div class="flex flex-wrap items-center gap-2 mb-3">
+      <span class="lbl mb-0 mr-1">Situation</span>
+      <button class="pill" data-mode="ordinary">Ordinary wall</button>
+      <button class="pill on" data-mode="onBase">Wall on base</button>
+      <button class="pill" data-mode="watertight">Watertight</button>
+      <label class="flex items-center gap-1.5 text-xs text-slate-300 ml-2">
+        <input type="checkbox" id="rtb" class="accent-sky-500"> also restrained top and bottom
+      </label>
+      <span id="modeHint" class="text-xs text-slate-500 ml-auto"></span>
+    </div>
+
+    <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2 mb-3">
+      <div><span class="lbl">Thickness t</span><input id="t" class="fld" value="350"></div>
+      <div><span class="lbl">Concrete</span>
+        <select id="fck" class="fld">
+          <option>20</option><option>25</option><option>30</option><option selected>35</option>
+          <option>40</option><option>45</option><option>50</option><option>55</option><option>60</option>
+        </select></div>
+      <div><span class="lbl">f<sub>yk</sub></span><input id="fyk" class="fld" value="500"></div>
+      <div><span class="lbl">Layers</span>
+        <select id="layers" class="fld"><option value="2" selected>2 — one per face</option><option value="1">1 — central</option></select></div>
+      <div><span class="lbl">Cover c<sub>nom</sub></span><input id="cover" class="fld" value="35"></div>
+      <div><span class="lbl">Wall side</span>
+        <select id="side" class="fld"><option value="exterior" selected>Exterior (yttervegg)</option><option value="interior">Interior (innervegg)</option></select></div>
+      <div><span class="lbl">Vert. bar ø</span>
+        <select id="vdia" class="fld"><option>8</option><option>10</option><option selected>12</option><option>16</option><option>20</option><option>25</option></select></div>
+      <div><span class="lbl">Vert. bar cc</span><input id="vcc" class="fld" value="250"></div>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="lbl mb-0 mr-1">Crack requirement</span>
+      <button class="pill" data-crack="none">None required</button>
+      <button class="pill" data-crack="wk040">w<sub>k</sub> 0,40</button>
+      <button class="pill on" data-crack="wk030">w<sub>k</sub> 0,30</button>
+      <button class="pill" data-crack="wk020">w<sub>k</sub> 0,20</button>
+      <button class="pill" data-crack="watertight">Watertight</button>
+      <button class="pill" data-crack="custom">Custom</button>
+
+      <label class="flex items-center gap-1.5 text-xs text-slate-300 ml-2" id="upliftWrap">
+        <input type="checkbox" id="uplift" class="accent-sky-500"> NA 0,30·k<sub>c</sub>
+      </label>
+      <input id="cnom" class="fld hidden" style="width:5rem" value="35" title="cnom">
+      <input id="cmindur" class="fld hidden" style="width:5rem" value="25" title="cmin,dur">
+      <div id="hDWrap" class="hidden items-center gap-1.5"><span class="lbl mb-0">h<sub>D</sub></span><input id="hD" class="fld" style="width:6rem" value="2000"></div>
+      <div id="wkWrap" class="hidden items-center gap-1.5"><span class="lbl mb-0">w<sub>k</sub></span><input id="wkCustom" class="fld" style="width:5rem" value="0.30"></div>
+      <span id="wkOut" class="text-xs text-slate-400 ml-auto"></span>
+    </div>
+
+    <details class="mt-3 border-t border-slate-800 pt-2">
+      <summary class="text-xs text-sky-400 hover:text-sky-300 select-none">Assumptions &amp; restraint zone ▾</summary>
+      <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2 mt-2">
+        <div><span class="lbl">k<sub>c</sub> (7.1)</span>
+          <select id="kcMode" class="fld">
+            <option value="pureTension" selected>1,0 pure tension</option>
+            <option value="house">0,6 house rule (NO)</option>
+            <option value="custom">custom</option>
+          </select></div>
+        <div><span class="lbl">k<sub>c</sub> value</span><input id="kcCustom" class="fld" value="1.0" disabled></div>
+        <div><span class="lbl">k (7.1)</span>
+          <select id="kMode" class="fld"><option value="external" selected>1,0 external restraint</option><option value="ec2h">EC2 h-interpolation</option></select></div>
+        <div><span class="lbl">Cracking at</span>
+          <select id="age" class="fld"><option value="28" selected>28 days</option><option value="7">7 days</option><option value="3">3 days</option></select></div>
+        <div><span class="lbl">Cement</span>
+          <select id="cement" class="fld"><option value="N" selected>CEM N</option><option value="R">CEM R</option><option value="S">CEM S</option></select></div>
+        <div><span class="lbl">Wall length L</span><input id="wallL" class="fld" placeholder="optional"></div>
+        <div><span class="lbl">Wall height H</span><input id="wallH" class="fld" placeholder="optional"></div>
+        <div><span class="lbl">ε<sub>free</sub> / ε<sub>ctu</sub> [µ]</span>
+          <div class="flex gap-1"><input id="epsFree" class="fld" value="320"><input id="epsCtu" class="fld" value="100"></div></div>
+      </div>
+    </details>
+  </div>
+
+  <!-- ============ HEADLINE ============ -->
+  <div class="grid twocol gap-3" style="grid-template-columns: 340px 1fr;">
+
+    <div class="space-y-3">
+      <div class="panel p-3">
+        <div class="flex items-center justify-between mb-1">
+          <span class="lbl mb-0">Horizontal · each face</span>
+          <div class="flex gap-1" id="diaPicker"></div>
+        </div>
+        <div id="hAnswer" class="text-3xl font-bold text-white leading-none mb-1">—</div>
+        <div id="hArea" class="text-sm text-slate-300 num"></div>
+        <div id="hClause" class="text-xs mt-1"></div>
+        <div id="hZone" class="text-xs text-slate-400 mt-2 pt-2 border-t border-slate-800"></div>
+      </div>
+
+      <div class="panel p-3">
+        <span class="lbl">Vertical · each face</span>
+        <div id="vAnswer" class="text-2xl font-bold text-white leading-none mb-1">—</div>
+        <div id="vArea" class="text-sm text-slate-300 num"></div>
+        <div id="vClause" class="text-xs mt-1"></div>
+      </div>
+
+      <div class="panel p-3">
+        <span class="lbl">What governs · horizontal</span>
+        <div id="govBars" class="space-y-1.5 mt-1"></div>
+      </div>
+
+      <div class="panel p-3">
+        <span class="lbl">Checks</span>
+        <div id="checks" class="space-y-1.5 mt-1 text-xs"></div>
+      </div>
+    </div>
+
+    <div class="space-y-3">
+      <div class="panel p-3">
+        <div class="flex items-baseline justify-between mb-2">
+          <span class="lbl mb-0">Required area and spacing, per bar size · each face</span>
+          <div class="flex items-center gap-1">
+            <span class="text-xs text-slate-500 mr-1">click a column to select</span>
+            <button class="pill sm on" data-method="simplified">7.3.3 simplified</button>
+            <button class="pill sm" data-method="direct">7.3.4 direct</button>
+          </div>
+        </div>
+        <div class="overflow-x-auto"><table class="grid w-full" id="heroTable"></table></div>
+        <div id="heroNote" class="text-xs text-slate-500 mt-2"></div>
+      </div>
+
+      <div class="panel p-3">
+        <div class="flex items-center justify-between mb-2">
+          <span class="lbl mb-0">A<sub>s</sub> provided [mm²/m] · green = meets the requirement for that bar</span>
+          <div class="flex gap-1">
+            <button class="pill sm on" data-dir="h">Horizontal</button>
+            <button class="pill sm" data-dir="v">Vertical</button>
+          </div>
+        </div>
+        <div class="overflow-x-auto"><table class="grid w-full" id="matrix"></table></div>
+        <div class="flex flex-wrap gap-3 mt-2 text-xs text-slate-500">
+          <span><span class="inline-block w-3 h-3 rounded-sm align-middle c-ok"></span> meets</span>
+          <span><span class="inline-block w-3 h-3 rounded-sm align-middle c-near"></span> within 5 %</span>
+          <span><span class="inline-block w-3 h-3 rounded-sm align-middle c-bad"></span> short</span>
+          <span><span class="inline-block w-3 h-3 rounded-sm align-middle c-cap"></span> spacing above the code maximum</span>
+          <span>◇ cheapest option in that column</span>
+        </div>
+      </div>
+
+      <div class="panel p-3" id="warnPanel">
+        <span class="lbl">Notes</span>
+        <div id="warnings" class="space-y-2 mt-1 text-xs text-slate-300"></div>
+      </div>
+    </div>
+  </div>
+
+  <p class="text-xs text-slate-600 mt-4 leading-relaxed">
+    Minimum reinforcement only. This tool does not design for bending, shear or in-plane forces, and a wall
+    governed by out-of-plane bending follows the slab rules of §9.3 rather than §9.6. Values from the Norwegian
+    National Annex should be confirmed against your own copy of NA:2010. Always check results independently.
+  </p>
+</div>
+
+<script src="wall_min_reinf_api.js"></script>
+<script src="script.js"></script>
+<script src="../assets/js/common.js"></script>
+<script src="../assets/js/cookie-consent.js"></script>
+</body>
+</html>

--- a/concrete_wall_minimum_reinforcement/print.css
+++ b/concrete_wall_minimum_reinforcement/print.css
@@ -1,0 +1,21 @@
+/* Print layout: one page, inputs then the answer then the table. */
+@media print {
+  body { background:#fff !important; color:#000 !important; }
+  .panel { background:#fff !important; border:1px solid #999 !important; break-inside:avoid; }
+  a[href]:after { content:""; }
+  .lbl { color:#444 !important; }
+  .fld, .pill { background:#fff !important; color:#000 !important; border-color:#999 !important; }
+  .pill:not(.on) { display:none; }
+  .pill.on { border:1px solid #000 !important; font-weight:700; }
+  .text-white, .text-slate-200, .text-slate-300 { color:#000 !important; }
+  .text-slate-400, .text-slate-500, .text-slate-600 { color:#444 !important; }
+  .text-sky-300, .text-sky-400 { color:#000 !important; }
+  .c-ok   { background:#e8f6ee !important; color:#065f46 !important; }
+  .c-near { background:#fdf6e3 !important; color:#7c5800 !important; }
+  .c-bad  { background:#fdeaee !important; color:#9f1239 !important; }
+  .c-cap, .c-veto { background:#f1f1f1 !important; color:#666 !important; background-image:none !important; }
+  details { display:block; }
+  details > summary { display:none; }
+  #cookie-settings-btn { display:none !important; }
+  .twocol { grid-template-columns:1fr !important; }
+}

--- a/concrete_wall_minimum_reinforcement/script.js
+++ b/concrete_wall_minimum_reinforcement/script.js
@@ -116,6 +116,7 @@
     paintHeadline(r);
     paintGovBars(r);
     paintHeroTable(r, dias);
+    paintVertTable(r, dias);
     paintMatrix(r, dias);
     paintChecks(r);
     paintWarnings(r);
@@ -221,8 +222,8 @@
       });
       $('heroTable').innerHTML =
         row('th', 'ø [mm]', cells.map(c => '<b>' + c.d + '</b>')) +
-        row('td', 'A<sub>s</sub> required', cells.map(() => fmt(r.detailing.AsHMin, 0))) +
-        row('td', 'max spacing', cells.map(c => '<b class="text-sky-300">c' + fmt(Math.floor(c.cc / 5) * 5, 0) + '</b>'));
+        row('td', 'A<sub>s</sub> req [mm²/m]', cells.map(() => fmt(r.detailing.AsHMin, 0))) +
+        row('td', 'c/c max', cells.map(c => '<b class="text-sky-300">c' + fmt(Math.floor(c.cc / 5) * 5, 0) + '</b>'));
       $('heroNote').textContent = 'Detailing minimum only. Spacing is additionally capped at c400 by 9.6.3(2).';
       wireColumns();
       return;
@@ -243,9 +244,9 @@
       row('th', 'ø [mm]', dias.map(d => '<b>' + d + '</b>'), dias) +
       (direct ? '' : row('td', 'φ*<sub>s</sub> needed', S.map(b => cell(b, 'phiStarReq', 1)))) +
       row('td', 'σ<sub>s</sub> [MPa]', S.map(b => cell(b, 'sigmaS', 0))) +
-      row('td', 'A<sub>s</sub> required [mm²/m]', S.map(b => cell(b, 'AsReq', 0))) +
-      row('td', 'max spacing · ' + (direct ? '7.3.4 direct' : '7.3.3'), S.map(ccCell)) +
-      row('td', 'max spacing · ' + (direct ? '7.3.3' : '7.3.4 direct'), D.map(ccCell)) +
+      row('td', 'A<sub>s</sub> req [mm²/m]', S.map(b => cell(b, 'AsReq', 0))) +
+      row('td', 'c/c max · ' + (direct ? '7.3.4' : '7.3.3'), S.map(ccCell)) +
+      row('td', 'c/c max · ' + (direct ? '7.3.3' : '7.3.4'), D.map(ccCell)) +
       row('td', 'verdict', S.map(b => {
         if (!b || b.status === 'outOfTable') return '<span class="text-rose-400" title="beyond Table 7.2N">bar too large</span>';
         if (b.status === 'wkOutOfRange') return '<span class="text-slate-600">—</span>';
@@ -262,7 +263,7 @@
       note += ' For ø' + state.selectedDia + ' the direct route of 7.3.4 asks for ' + fmt(selD.AsReq, 0) +
         ' mm²/m against ' + fmt(sel.AsReq, 0) + ' from the simplified route.';
     }
-    $('heroNote').innerHTML = note;
+    $('heroNote').innerHTML = note + ' Spacings round down to 5 mm.';
     wireColumns();
   }
 
@@ -283,6 +284,50 @@
       el.addEventListener('click', () => {
         state.selectedDia = parseFloat(el.dataset.col);
         state.diaAuto = false;
+        render();
+      });
+    });
+  }
+
+  /* Same shape as the horizontal table, but the vertical requirement does not vary with
+     bar size - 9.6.2(1) is a flat area - so the interesting column is the spacing. */
+  function paintVertTable(r, dias) {
+    const need = r.governing.vertical.As;
+    const cap = r.detailing.sVMax;
+    const chosen = r.inputs.vBar.dia;
+
+    const cells = dias.map(d => {
+      const byArea = 1000 * Math.PI * d * d / 4 / need;
+      const cc = Math.floor(Math.min(byArea, cap) / 5) * 5;
+      return { d, cc, capped: byArea > cap };
+    });
+
+    const hdr = (c) => '<th data-vcol="' + c.d + '" style="cursor:pointer"' +
+      (c.d === chosen ? ' class="c-pick"' : '') + '><b>' + c.d + '</b></th>';
+    const td = (c, html, extra) => '<td data-vcol="' + c.d + '" style="cursor:pointer"' +
+      (c.d === chosen ? ' class="c-pick"' : '') + (extra || '') + '>' + html + '</td>';
+
+    const lead = (txt) => '<td style="text-align:left;color:#7f92ad">' + txt + '</td>';
+
+    let html = '<tr><th style="text-align:left;color:#7f92ad;font-weight:500">\u00f8 [mm]</th>' +
+      cells.map(hdr).join('') + '</tr>';
+    html += '<tr>' + lead('A<sub>s</sub> req [mm\u00b2/m]') +
+      cells.map(c => td(c, fmt(need, 0))).join('') + '</tr>';
+    html += '<tr>' + lead('c/c max') +
+      cells.map(c => td(c,
+        '<b class="' + (c.capped ? 'text-slate-400' : 'text-sky-300') + '">c' + c.cc + '</b>',
+        c.capped ? ' title="capped by 9.6.2(3), min(3t, 400)"' : '')).join('') + '</tr>';
+    $('vertTable').innerHTML = html;
+
+    const anyCapped = cells.some(c => c.capped);
+    $('vertNote').innerHTML = '<b class="text-slate-400">' + esc(r.governing.vertical.clause) + '</b> \u00b7 ' +
+      'one area for every bar, so only the spacing moves. Capped at c' + fmt(cap, 0) +
+      ' by 9.6.2(3)' + (anyCapped ? '; greyed values sit at that cap' : '') +
+      '. Spacings round down to 5 mm.';
+
+    $('vertTable').querySelectorAll('[data-vcol]').forEach(el => {
+      el.addEventListener('click', () => {
+        $('vdia').value = el.dataset.vcol;
         render();
       });
     });
@@ -355,6 +400,187 @@
       '<div class="border-l-2 border-amber-500/50 pl-2 leading-snug">' + esc(w) + '</div>').join('');
   }
 
+
+  // ---------------------------------------------------------------- tooltips
+  /* One place for every explanation. Keys are attached to elements by TIP_TARGETS
+     below, so the markup stays free of prose. */
+  const TIPS = {
+    'mode.ordinary': ['Ordinary wall',
+      'A wall with no significant restraint \u2014 above ground, free to shrink. Only the detailing minima ' +
+      'run: 9.6.2 for the vertical bars, NA.9.6.3 for the horizontal. \u00a77.3.2 is switched off, so the ' +
+      'horizontal steel falls to the code floor.'],
+    'mode.onBase': ['Wall on base',
+      'A wall cast on a hardened foundation \u2014 basement, retaining wall, lift shaft. The base stops the ' +
+      'wall shrinking along its length, so the tension runs <em>horizontally</em> and the cracks are ' +
+      'vertical. \u00a77.3.2 is applied to the horizontal bars only, and typically multiplies them by three.'],
+    'mode.watertight': ['Watertight wall',
+      'EN 1992-3 Tightness Class 1. The crack width stops being your choice and follows the head over the ' +
+      'wall thickness: 0,20 mm at h<sub>D</sub>/h \u2264 5, down to 0,05 mm at \u2265 35. Bar sizes use ' +
+      'eq. (7.122), with 10 in place of the 8 in (7.7N). Below w<sub>k</sub> 0,20 Table 7.2N runs out and ' +
+      'the direct calculation of 7.3.4 takes over automatically.'],
+    'rtb': ['Restrained top and bottom',
+      'For a wall cast <em>between</em> two slabs the vertical direction is restrained as well, so \u00a77.3.2 ' +
+      'is applied to the vertical bars too. Leave it off for a wall free to shorten vertically, which is the ' +
+      'usual case and why vertical steel is normally detailing-driven.'],
+
+    'crack.none': ['No crack control required',
+      'Switches \u00a77.3.2 off entirely and leaves only \u00a79.6. Legitimate where cracking impairs neither ' +
+      'function, durability nor appearance \u2014 and also where movement joints are provided instead, since ' +
+      'EN 1992-3 Table N.1(b) then asks only for 9.6.2 to 9.6.4. This is the cheapest answer the code allows, ' +
+      'and it is a decision you own rather than one the tool makes.'],
+    'crack.wk040': ['w<sub>k</sub> = 0,40 mm',
+      'Exposure class X0 under the quasi-permanent combination, per NA Table NA.7.1N.'],
+    'crack.wk030': ['w<sub>k</sub> = 0,30 mm',
+      'XC1\u2013XC4, XD1\u2013XD2 and XS1\u2013XS2 quasi-permanent; XD3, XS3 and XSA frequent. The Norwegian NA ' +
+      'scales this by k<sub>c</sub> = c<sub>nom</sub>/c<sub>min,dur</sub> capped at 1,3 \u2014 tick the box ' +
+      'alongside to use it, so extra cover buys a wider permitted crack.'],
+    'crack.wk020': ['w<sub>k</sub> = 0,20 mm',
+      'Tighter than the NA asks for in ordinary exposure. Use it when a client or specification demands it, ' +
+      'and watch what it costs in the table on the right.'],
+    'crack.watertight': ['EN 1992-3 Class 1',
+      'w<sub>k1</sub> interpolated on the hydrostatic head over the wall thickness. Enter the head beside.'],
+    'crack.custom': ['Custom crack width',
+      'Any target you like. Below 0,20 mm Table 7.2N cannot answer and the tool switches to the direct ' +
+      'calculation of 7.3.4 on its own.'],
+    'uplift': ['NA cover uplift',
+      'NA.7.3.1(5): the permitted crack width scales with cover, k<sub>c</sub> = ' +
+      'c<sub>nom</sub>/c<sub>min,dur</sub>, capped at 1,3. With 35 over 25 that is 0,30 \u00d7 1,3 = 0,39 mm.'],
+
+    'f.t': ['Wall thickness',
+      'Drives everything: A<sub>c</sub> = 1000 \u00b7 t for both the NA.9.6.3 leg and A<sub>ct</sub> in ' +
+      'eq. (7.1), the 3t zone height, and the min(3t, 400) spacing cap of 9.6.2(3).'],
+    'f.fck': ['Concrete class',
+      'Sets f<sub>ctm</sub> = 0,30 \u00b7 f<sub>ck</sub><sup>2/3</sup> from the closed form of Table 3.1, not ' +
+      'a lookup \u2014 so every class works, including the ones a three-row spreadsheet table would silently ' +
+      'return zero for. Stronger concrete cracks at a higher force, so it needs <em>more</em> minimum steel.'],
+    'f.fyk': ['Steel grade',
+      'Divides the NA.9.6.3 leg, and sets the absolute floor A<sub>s</sub> \u2265 ' +
+      'k<sub>c</sub>\u00b7k\u00b7f<sub>ct,eff</sub>\u00b7A<sub>ct</sub>/f<sub>yk</sub> below which the bars ' +
+      'yield the instant the section cracks.'],
+    'f.layers': ['Reinforcement layers',
+      'Two layers means one mesh per face. A single central layer sits t/2 from the surface, which eq. (7.7N) ' +
+      'punishes hard \u2014 under edge restraint it usually cannot be crack-controlled at all. The detailing ' +
+      'minima change too: 9.6.3(1) wants A<sub>s,hmin</sub> at <em>each</em> surface, so one layer must ' +
+      'provide double.'],
+    'f.cover': ['Cover to the horizontal bar',
+      'Enter c<sub>nom</sub>. 9.6.3 puts the horizontal steel at the surface and in a wall it is normally the ' +
+      'outer layer for exactly that reason. Cover sets the lever arm in eq. (7.7N) and the 3,4\u00b7c term in ' +
+      'the crack spacing (7.11).'],
+    'f.side': ['Exterior or interior',
+      'NA.9.6.3 uses k = 0,30 for a wall exposed to outdoor climate and 0,15 for one indoors \u2014 an exterior ' +
+      'wall sees roughly twice the restrained strain. A basement wall with earth on one side is normally taken ' +
+      'as exterior.'],
+    'f.vbar': ['Vertical steel you intend to provide',
+      'Feeds the \u201c25 % of the vertical reinforcement\u201d leg of NA.9.6.3, the 9.6.4 links trigger, and the ' +
+      'pass mark on the vertical card. It does not affect the horizontal crack calculation.'],
+
+    'f.kc': ['k<sub>c</sub> in eq. (7.1)',
+      '1,0 is pure tension, which is what edge restraint produces and the right default here. 0,6 is the ' +
+      'Norwegian house rule carried over from the source spreadsheet \u2014 there is no clause behind it, so it ' +
+      'is offered as a labelled choice rather than a hidden constant. Halving k<sub>c</sub> halves the steel.'],
+    'f.k': ['k in eq. (7.1)',
+      'k allows for non-uniform self-equilibrating stresses, which arise only from <em>internal</em> restraint. ' +
+      'A wall held by its base is restrained <em>externally</em>, so k = 1,0. The EC2 interpolation on thickness ' +
+      '(1,0 at 300 mm to 0,65 at 800 mm) is offered for the internal-restraint case.'],
+    'f.age': ['Age at cracking',
+      'Sets f<sub>ct,eff</sub> in eq. (7.1). Early-age restraint cracking normally happens well before 28 days, ' +
+      'and 7.3.2(2) lets you use f<sub>ctm</sub>(t) \u2014 the largest legitimate reduction on the table, worth ' +
+      'about 40 % at three days. Several National Annexes impose a floor, so confirm against NA:2010.'],
+    'f.cement': ['Cement class',
+      'Only matters when cracking is taken before 28 days: it sets s in \u03b2<sub>cc</sub>(t), eq. (3.2). ' +
+      'R gains strength fastest, S slowest.'],
+    'f.LH': ['Wall length and height',
+      'Optional. Give both and the EN 1992-3 Table L.1 restraint curve checks the 3t zone height for you. ' +
+      'Restraint at the base is always 0,5; what L/H changes is the top, and above L/H \u2248 4 the whole ' +
+      'height is restrained \u2014 which is where the 3t rule of thumb goes wrong.'],
+    'f.eps': ['Free strain and strain capacity',
+      'In microstrain. Their ratio is the restraint factor below which no crack forms, and that threshold read ' +
+      'off the Table L.1 curve is what fixes the height of the cracked zone. Typical Norwegian early-thermal ' +
+      'values are around 320 and 100.'],
+
+    'method.simplified': ['7.3.3 simplified',
+      'Table 7.2N with the eq. (7.7N) size adjustment \u2014 the familiar route, and what the office spreadsheet ' +
+      'does. Note 1 to the table says it is derived for <em>bending</em> (k<sub>2</sub> = 0,5, ' +
+      'k<sub>c</sub> = 0,4, h<sub>cr</sub> = 0,5h), so for a wall in uniform tension it runs roughly 10\u201315 % ' +
+      'light. Compliant under 7.3.1(9), but read the row below it.'],
+    'method.direct': ['7.3.4 direct',
+      'The crack width computed from (7.8), (7.9) and (7.11) with k<sub>2</sub> = 1,0 for pure tension, solved ' +
+      'for the area that hits your target. More faithful for restraint cracking, and the only route available ' +
+      'below w<sub>k</sub> 0,20.'],
+
+    'dir.h': ['Horizontal bars',
+      'The direction that carries edge restraint. Each column has its own threshold, because the permitted ' +
+      'steel stress depends on the bar size.'],
+    'dir.v': ['Vertical bars',
+      'One threshold for every column \u2014 0,002\u00b7A<sub>c</sub> split between the faces \u2014 and the ' +
+      'spacing cap tightens to min(3t, 400).'],
+    'diaPicker': ['Bar size',
+      'The tool starts on the cheapest buildable bar. Pick another and the headline follows it; press ' +
+      '\u201cauto\u201d to hand the choice back.']
+  };
+
+  /* selector -> [tip key, attach to the parent instead of the element itself] */
+  const TIP_TARGETS = [
+    ['[data-mode="ordinary"]', 'mode.ordinary'], ['[data-mode="onBase"]', 'mode.onBase'],
+    ['[data-mode="watertight"]', 'mode.watertight'],
+    ['[data-crack="none"]', 'crack.none'], ['[data-crack="wk040"]', 'crack.wk040'],
+    ['[data-crack="wk030"]', 'crack.wk030'], ['[data-crack="wk020"]', 'crack.wk020'],
+    ['[data-crack="watertight"]', 'crack.watertight'], ['[data-crack="custom"]', 'crack.custom'],
+    ['[data-method="simplified"]', 'method.simplified'], ['[data-method="direct"]', 'method.direct'],
+    ['[data-dir="h"]', 'dir.h'], ['[data-dir="v"]', 'dir.v'],
+    ['#rtb', 'rtb', 'parent'], ['#upliftWrap', 'uplift'],
+    ['#t', 'f.t', 'parent'], ['#fck', 'f.fck', 'parent'], ['#fyk', 'f.fyk', 'parent'],
+    ['#layers', 'f.layers', 'parent'], ['#cover', 'f.cover', 'parent'], ['#side', 'f.side', 'parent'],
+    ['#vdia', 'f.vbar', 'parent'], ['#vcc', 'f.vbar', 'parent'],
+    ['#kcMode', 'f.kc', 'parent'], ['#kcCustom', 'f.kc', 'parent'], ['#kMode', 'f.k', 'parent'],
+    ['#age', 'f.age', 'parent'], ['#cement', 'f.cement', 'parent'],
+    ['#wallL', 'f.LH', 'parent'], ['#wallH', 'f.LH', 'parent'], ['#epsFree', 'f.eps', 'parent'],
+    ['#diaPicker', 'diaPicker']
+  ];
+
+  function initTips() {
+    for (const [sel, key, mode] of TIP_TARGETS) {
+      document.querySelectorAll(sel).forEach(el => {
+        const host = mode === 'parent' ? el.parentElement : el;
+        if (!host) return;
+        host.dataset.tip = key;
+        const lbl = host.querySelector ? host.querySelector('.lbl') : null;
+        if (lbl) lbl.dataset.tip = key;                    // dotted underline affordance
+      });
+    }
+
+    const box = $('tip');
+    let hideTimer = null;
+
+    const show = (host) => {
+      const t = TIPS[host.dataset.tip];
+      if (!t) return;
+      clearTimeout(hideTimer);
+      box.innerHTML = '<b>' + t[0] + '</b>' + t[1];
+      box.classList.add('on');
+      const r = host.getBoundingClientRect();
+      const b = box.getBoundingClientRect();
+      let x = Math.min(Math.max(8, r.left), window.innerWidth - b.width - 8);
+      let y = r.bottom + 8;
+      if (y + b.height > window.innerHeight - 8) y = Math.max(8, r.top - b.height - 8);
+      box.style.left = x + 'px';
+      box.style.top = y + 'px';
+    };
+    const hide = () => { hideTimer = setTimeout(() => box.classList.remove('on'), 60); };
+
+    document.addEventListener('mouseover', (e) => {
+      const host = e.target.closest('[data-tip]');
+      if (host) show(host); else hide();
+    });
+    document.addEventListener('focusin', (e) => {
+      const host = e.target.closest('[data-tip]');
+      if (host) show(host);
+    });
+    document.addEventListener('focusout', hide);
+    window.addEventListener('scroll', () => box.classList.remove('on'), true);
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') box.classList.remove('on'); });
+  }
+
   // ------------------------------------------------------------------ wiring
 
   function init() {
@@ -400,6 +626,7 @@
         el.addEventListener('change', render);
       });
 
+    initTips();
     render();
   }
 

--- a/concrete_wall_minimum_reinforcement/script.js
+++ b/concrete_wall_minimum_reinforcement/script.js
@@ -466,10 +466,15 @@
       'Enter c<sub>nom</sub>. 9.6.3 puts the horizontal steel at the surface and in a wall it is normally the ' +
       'outer layer for exactly that reason. Cover sets the lever arm in eq. (7.7N) and the 3,4\u00b7c term in ' +
       'the crack spacing (7.11).'],
-    'f.side': ['Exterior or interior',
-      'NA.9.6.3 uses k = 0,30 for a wall exposed to outdoor climate and 0,15 for one indoors \u2014 an exterior ' +
-      'wall sees roughly twice the restrained strain. A basement wall with earth on one side is normally taken ' +
-      'as exterior.'],
+    'f.side': ['Exterior or interior wall',
+      'NA.9.6.3 replaces EC2\u2019s recommended A<sub>s,hmin</sub> = 0,001\u00b7A<sub>c</sub> with ' +
+      'k\u00b7A<sub>c</sub>\u00b7f<sub>ctm</sub>/f<sub>yk</sub>: k = 0,30 exposed to outdoor climate, ' +
+      '0,15 indoors. The 0,15 is not an arbitrary halving \u2014 across B25 to B45 it lands on 0,08\u20130,11 % ' +
+      'of the section, which <em>is</em> the EC2 recommendation, just re-expressed so it scales with the ' +
+      'cracking force instead of being a flat 0,1 %. Exterior is double that. Anything weather-exposed or cast ' +
+      'against soil \u2014 facade, basement, retaining wall, lift pit, culvert \u2014 is normally taken as ' +
+      'exterior. It only decides the answer when crack control is off; with \u00a77.3.2 active the crack ' +
+      'requirement is usually well above both legs and the choice stops mattering.'],
     'f.vbar': ['Vertical steel you intend to provide',
       'Feeds the \u201c25 % of the vertical reinforcement\u201d leg of NA.9.6.3, the 9.6.4 links trigger, and the ' +
       'pass mark on the vertical card. It does not affect the horizontal crack calculation.'],

--- a/concrete_wall_minimum_reinforcement/script.js
+++ b/concrete_wall_minimum_reinforcement/script.js
@@ -69,7 +69,15 @@
     $('cnom').className = showCov ? 'fld' : 'fld hidden';
     $('cmindur').className = showCov ? 'fld' : 'fld hidden';
     if (showCov) { $('cnom').style.width = '5rem'; $('cmindur').style.width = '5rem'; }
-    $('kcCustom').disabled = $('kcMode').value !== 'custom';
+    const tight = state.mode === 'watertight';
+    ['kcMode', 'kMode', 'age', 'cement'].forEach(id => {
+      $(id).disabled = tight;
+      $(id).style.opacity = tight ? '.45' : '';
+      $(id).title = tight
+        ? 'Fixed by NA.9.6.3(1) for a tightness-critical wall: eq. (7.1) with fct,eff = fctm and k = kc = 1,0.'
+        : '';
+    });
+    $('kcCustom').disabled = tight || $('kcMode').value !== 'custom';
     if ($('kcMode').value === 'pureTension') $('kcCustom').value = '1.0';
     if ($('kcMode').value === 'house') $('kcCustom').value = '0.6';
   }
@@ -414,6 +422,10 @@
       'wall shrinking along its length, so the tension runs <em>horizontally</em> and the cracks are ' +
       'vertical. \u00a77.3.2 is applied to the horizontal bars only, and typically multiplies them by three.'],
     'mode.watertight': ['Watertight wall',
+      'Turns on the NA\u2019s tightness rules, which are not optional. NA.9.6.2 doubles the vertical ' +
+      'minimum to 0,004\u00b7A<sub>c</sub>, and NA.9.6.3(1) fixes eq. (7.1) at f<sub>ct,eff</sub> = ' +
+      'f<sub>ctm</sub> with k = k<sub>c</sub> = 1,0 \u2014 so the k<sub>c</sub>, k and cracking-age inputs ' +
+      'are locked. ' +
       'EN 1992-3 Tightness Class 1. The crack width stops being your choice and follows the head over the ' +
       'wall thickness: 0,20 mm at h<sub>D</sub>/h \u2264 5, down to 0,05 mm at \u2265 35. Bar sizes use ' +
       'eq. (7.122), with 10 in place of the 8 in (7.7N). Below w<sub>k</sub> 0,20 Table 7.2N runs out and ' +
@@ -424,8 +436,10 @@
       'usual case and why vertical steel is normally detailing-driven.'],
 
     'crack.none': ['No crack control required',
-      'Switches \u00a77.3.2 off entirely and leaves only \u00a79.6. Legitimate where cracking impairs neither ' +
-      'function, durability nor appearance \u2014 and also where movement joints are provided instead, since ' +
+      'Switches \u00a77.3.2 off entirely and leaves only \u00a79.6. The NA supports this: footnote 1 to Table ' +
+      'NA.7.1N says that in X0 the crack width does not affect durability and the 0,40 limit is there for ' +
+      'appearance, so where appearance is not a constraint the value may be increased. Also where movement ' +
+      'joints are provided instead, since ' +
       'EN 1992-3 Table N.1(b) then asks only for 9.6.2 to 9.6.4. This is the cheapest answer the code allows, ' +
       'and it is a decision you own rather than one the tool makes.'],
     'crack.wk040': ['w<sub>k</sub> = 0,40 mm',
@@ -460,8 +474,9 @@
     'f.layers': ['Reinforcement layers',
       'Two layers means one mesh per face. A single central layer sits t/2 from the surface, which eq. (7.7N) ' +
       'punishes hard \u2014 under edge restraint it usually cannot be crack-controlled at all. The detailing ' +
-      'minima change too: 9.6.3(1) wants A<sub>s,hmin</sub> at <em>each</em> surface, so one layer must ' +
-      'provide double.'],
+      'minimum changes too: NA.9.6.3(1) states the horizontal minimum per face for <em>doubly</em> reinforced ' +
+      'walls, and that a singly reinforced wall shall carry the corresponding <em>total</em> area \u2014 so ' +
+      'the one layer has to provide what two faces would have provided between them.'],
     'f.cover': ['Cover to the horizontal bar',
       'Enter c<sub>nom</sub>. 9.6.3 puts the horizontal steel at the surface and in a wall it is normally the ' +
       'outer layer for exactly that reason. Cover sets the lever arm in eq. (7.7N) and the 3,4\u00b7c term in ' +
@@ -480,6 +495,7 @@
       'pass mark on the vertical card. It does not affect the horizontal crack calculation.'],
 
     'f.kc': ['k<sub>c</sub> in eq. (7.1)',
+      'Locked to 1,0 in the watertight mode, where NA.9.6.3(1) fixes it. Otherwise: ' +
       '1,0 is pure tension, which is what edge restraint produces and the right default here. 0,6 is the ' +
       'Norwegian house rule carried over from the source spreadsheet \u2014 there is no clause behind it, so it ' +
       'is offered as a labelled choice rather than a hidden constant. Halving k<sub>c</sub> halves the steel.'],
@@ -488,7 +504,9 @@
       'A wall held by its base is restrained <em>externally</em>, so k = 1,0. The EC2 interpolation on thickness ' +
       '(1,0 at 300 mm to 0,65 at 800 mm) is offered for the internal-restraint case.'],
     'f.age': ['Age at cracking',
-      'Sets f<sub>ct,eff</sub> in eq. (7.1). Early-age restraint cracking normally happens well before 28 days, ' +
+      'Ignored in the watertight mode, where NA.9.6.3(1) requires f<sub>ct,eff</sub> = f<sub>ctm</sub> at ' +
+      '28 days. Otherwise: ' +
+      'sets f<sub>ct,eff</sub> in eq. (7.1). Early-age restraint cracking normally happens well before 28 days, ' +
       'and 7.3.2(2) lets you use f<sub>ctm</sub>(t) \u2014 the largest legitimate reduction on the table, worth ' +
       'about 40 % at three days. Several National Annexes impose a floor, so confirm against NA:2010.'],
     'f.cement': ['Cement class',

--- a/concrete_wall_minimum_reinforcement/script.js
+++ b/concrete_wall_minimum_reinforcement/script.js
@@ -1,0 +1,413 @@
+/* UI layer for the wall minimum reinforcement tool. All arithmetic lives in
+   wall_min_reinf_api.js — this file only reads the form and paints the result. */
+(function () {
+  'use strict';
+
+  const $ = (id) => document.getElementById(id);
+  const API = () => window.WallMinReinf;
+
+  const state = {
+    mode: 'onBase',
+    crackReq: 'wk030',
+    selectedDia: 16,
+    diaAuto: true,          // until the user picks a bar themselves
+    method: 'simplified',
+    matrixDir: 'h'
+  };
+
+  const n = (v) => {
+    const x = parseFloat(String(v).replace(',', '.'));
+    return isFinite(x) ? x : null;
+  };
+  const fmt = (v, dp) => (v == null || !isFinite(v)) ? '—' : v.toFixed(dp).replace('.', ',');
+  const esc = (s) => String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+
+  // ------------------------------------------------------------------ inputs
+
+  function readInputs() {
+    return {
+      mode: state.mode,
+      restrainedTopBottom: $('rtb').checked,
+      t: n($('t').value),
+      fck: n($('fck').value),
+      fyk: n($('fyk').value),
+      layers: n($('layers').value),
+      cover: n($('cover').value),
+      exposureSide: $('side').value,
+      vBar: { dia: n($('vdia').value), spacing: n($('vcc').value) },
+      crackReq: state.crackReq,
+      wkCustom: n($('wkCustom').value),
+      naCoverUplift: { on: $('uplift').checked, cnom: n($('cnom').value), cminDur: n($('cmindur').value) },
+      hD: n($('hD').value),
+      kcMode: $('kcMode').value,
+      kcCustom: n($('kcCustom').value),
+      kMode: $('kMode').value,
+      crackAgeDays: n($('age').value),
+      cementClass: $('cement').value,
+      method: state.method,
+      selectedDia: state.selectedDia,
+      wallL: n($('wallL').value),
+      wallH: n($('wallH').value),
+      epsFree: (n($('epsFree').value) || 320) * 1e-6,
+      epsCtu: (n($('epsCtu').value) || 100) * 1e-6
+    };
+  }
+
+  const MODE_HINT = {
+    ordinary: 'Detailing only. §9.6.2 vertical and NA.9.6.3 horizontal.',
+    onBase: 'Edge restraint from the base. The horizontal bars carry it — that is where §7.3.2 bites.',
+    watertight: 'EN 1992-3 Tightness Class 1. wk1 follows from the head over the thickness.'
+  };
+
+  function syncVisibility() {
+    $('modeHint').textContent = MODE_HINT[state.mode] || '';
+    $('hDWrap').className = state.crackReq === 'watertight' ? 'flex items-center gap-1.5' : 'hidden';
+    $('wkWrap').className = state.crackReq === 'custom' ? 'flex items-center gap-1.5' : 'hidden';
+    const upliftOn = state.crackReq === 'wk030';
+    $('upliftWrap').className = upliftOn ? 'flex items-center gap-1.5 text-xs text-slate-300 ml-2' : 'hidden';
+    const showCov = upliftOn && $('uplift').checked;
+    $('cnom').className = showCov ? 'fld' : 'fld hidden';
+    $('cmindur').className = showCov ? 'fld' : 'fld hidden';
+    if (showCov) { $('cnom').style.width = '5rem'; $('cmindur').style.width = '5rem'; }
+    $('kcCustom').disabled = $('kcMode').value !== 'custom';
+    if ($('kcMode').value === 'pureTension') $('kcCustom').value = '1.0';
+    if ($('kcMode').value === 'house') $('kcCustom').value = '0.6';
+  }
+
+  // ----------------------------------------------------------------- render
+
+  /* The cheapest buildable bar: least steel among the options someone can actually fix.
+     Falls back to the widest achievable spacing when nothing clears the buildable band. */
+  function autoDia(r) {
+    if (!r.crack.active) return null;
+    const list = r.crack.methodEffective === 'direct' ? r.crack.barsDirect : r.crack.bars;
+    const ok = list.filter(b => b.AsReq != null && b.build === 'ok');
+    if (ok.length) return ok.reduce((a, b) => (b.AsReq < a.AsReq ? b : a)).dia;
+    const any = list.filter(b => b.AsReq != null);
+    if (any.length) return any.reduce((a, b) => (b.ccUncapped > a.ccUncapped ? b : a)).dia;
+    return null;
+  }
+
+  function render() {
+    syncVisibility();
+    let r = API().calculate(readInputs());
+    if (state.diaAuto) {
+      const best = autoDia(r);
+      if (best != null && best !== state.selectedDia) {
+        state.selectedDia = best;
+        r = API().calculate(readInputs());
+      }
+    }
+    const dias = r.constants.BAR_DIAMETERS;
+
+    $('wkOut').textContent = r.crack.active
+      ? r.crack.wkSource + '  ·  fct,eff = ' + fmt(r.material.fctEff, 2) + ' MPa  ·  kc = ' +
+        fmt(r.crack.kc, 2) + '  ·  k = ' + fmt(r.crack.k, 2)
+      : 'Crack control switched off — only the detailing minima of §9.6 apply.';
+
+    document.querySelectorAll('[data-method]').forEach(b => {
+      const forced = r.crack.active && !r.crack.tableCovers;
+      b.classList.toggle('on', b.dataset.method === r.crack.methodEffective);
+      b.disabled = forced;
+      b.style.opacity = forced && b.dataset.method === 'simplified' ? '.35' : '';
+      b.title = forced ? 'Table 7.2N does not span this crack width — the direct route is the only one available' : '';
+    });
+    paintDiaPicker(dias, r);
+    paintHeadline(r);
+    paintGovBars(r);
+    paintHeroTable(r, dias);
+    paintMatrix(r, dias);
+    paintChecks(r);
+    paintWarnings(r);
+  }
+
+  function paintDiaPicker(dias, r) {
+    $('diaPicker').innerHTML = (state.diaAuto ? '' :
+      '<button class="pill sm" data-dia="auto" title="return to the automatic pick">auto</button>') +
+      dias.map(d => {
+      const list = r.crack.methodEffective === 'direct' ? r.crack.barsDirect : r.crack.bars;
+      const b = list.find(x => x.dia === d);
+      const dead = r.crack.active && b && b.AsReq == null;
+      return '<button class="pill sm ' + (d === state.selectedDia ? 'on' : '') + '" data-dia="' + d + '"' +
+        (dead ? ' style="opacity:.4"' : '') + '>' + d + '</button>';
+    }).join('');
+  }
+
+  function paintHeadline(r) {
+    const h = r.governing.horizontal;
+    if (h.blocked) {
+      $('hAnswer').innerHTML = '<span class="text-rose-400">ø' + h.dia + ' will not do</span>';
+      $('hArea').textContent = h.blockReason === 'wkOutOfRange'
+        ? 'wk is outside Table 7.2N — use the direct route'
+        : 'the bar is larger than Table 7.2N permits at any stress for this wk';
+      $('hClause').innerHTML = '<span class="chk-fail">Pick a smaller bar, or relax the crack requirement.</span>';
+    } else {
+      const list = r.crack.methodEffective === 'direct' ? r.crack.barsDirect : r.crack.bars;
+      const selBar = list.find(b => b.dia === h.dia);
+      const cc = Math.floor(h.ccMax / 5) * 5;                 // round down to a buildable 5 mm step
+      const per = r.inputs.layers === 2 ? ' at each face' : ' in the single layer';
+      if (selBar && selBar.build === 'unbuildable') {
+        $('hAnswer').innerHTML = 'ø' + h.dia + ' <span class="text-rose-400">will not reach it</span>';
+        $('hArea').textContent = fmt(h.As, 0) + ' mm²/m' + per + ' would need c' +
+          fmt(selBar.ccUncapped, 0) + ' — below the 75 mm steel fixers can work to.';
+      } else {
+        const tone = !selBar || selBar.build === 'ok' ? 'text-sky-400' : 'text-amber-300';
+        $('hAnswer').innerHTML = 'ø' + h.dia + ' <span class="' + tone + '">c' + cc + '</span>' +
+          (selBar && selBar.build === 'tight' ? '<span class="text-amber-300 text-sm font-normal"> tight</span>' : '');
+        $('hArea').textContent = fmt(h.As, 0) + ' mm²/m required' + per +
+          (state.diaAuto && r.crack.active ? '  ·  cheapest buildable bar' : '');
+      }
+      $('hClause').innerHTML = '<span class="text-slate-400">governed by</span> <b>' + esc(h.clause) + '</b>' +
+        (h.ratio > 1.02 ? ' <span class="text-amber-400">· ' + fmt(h.ratio, 1) + '× the detailing minimum</span>' : '');
+    }
+
+    const v = r.governing.vertical;
+    const byArea = 1000 * Math.PI * Math.pow(r.inputs.vBar.dia, 2) / 4 / v.As;
+    const vccMax = Math.floor(Math.min(byArea, r.detailing.sVMax) / 5) * 5;
+    const entered = r.inputs.vBar.spacing;
+    const passes = r.detailing.AsVProv >= v.As && entered <= r.detailing.sVMax;
+    $('vAnswer').innerHTML = 'ø' + r.inputs.vBar.dia +
+      ' <span class="' + (passes ? 'text-sky-400' : 'text-rose-400') + '">c' + entered + '</span>' +
+      '<span class="text-sm font-normal ' + (passes ? 'text-emerald-400' : 'text-rose-400') + '"> ' +
+      (passes ? '✓' : '✗ short') + '</span>';
+    $('vArea').innerHTML = fmt(r.detailing.AsVProv, 0) + ' mm²/m provided against ' + fmt(v.As, 0) +
+      ' required.<br>Widest permissible spacing for ø' + r.inputs.vBar.dia + ': <b>c' + vccMax + '</b>' +
+      (byArea > r.detailing.sVMax ? ' (capped by 9.6.2(3), c' + fmt(r.detailing.sVMax, 0) + ')' : ' (area governs)');
+    $('vClause').innerHTML = '<span class="text-slate-400">governed by</span> <b>' + esc(v.clause) + '</b>';
+
+    const z = r.zone;
+    let zt = 'Extra horizontal steel over <b>' + fmt(z.practice, 0) + ' mm</b> from the base (3t — Norwegian practice, not an EC2 rule).';
+    if (z.tableL1) {
+      const T = z.tableL1;
+      if (T.note === 'noCracking') {
+        zt += '<br><span class="chk-ok">EN 1992-3 Table L.1: R_crit = ' + fmt(T.Rcrit, 2) +
+          ' exceeds the 0,50 base restraint — no restraint cracking predicted.</span>';
+      } else {
+        const worse = T.height > z.practice * 1.05;
+        zt += '<br><span class="' + (worse ? 'chk-warn' : 'chk-ok') + '">Table L.1 at L/H = ' + fmt(T.LH, 1) +
+          ': ' + (T.note === 'fullHeight' ? 'restrained over the <b>full height</b>' : '<b>' + fmt(T.height, 0) + ' mm</b>') +
+          (worse ? ' — 3t is unconservative here.' : '.') + '</span>';
+      }
+    } else {
+      zt += '<br><span class="text-slate-600">Enter L and H under Assumptions for the EN 1992-3 Table L.1 check.</span>';
+    }
+    $('hZone').innerHTML = zt;
+  }
+
+  function paintGovBars(r) {
+    const rows = [
+      { label: '9.6.2 vertical minimum', v: r.detailing.AsVMin, tone: '#64748b' },
+      { label: 'NA.9.6.3 horizontal minimum', v: r.detailing.AsHMin, tone: '#0ea5e9' }
+    ];
+    if (r.crack.active) {
+      const s = r.crack.bars.find(b => b.dia === state.selectedDia);
+      const d = r.crack.barsDirect.find(b => b.dia === state.selectedDia);
+      if (s && s.AsReq != null) rows.push({ label: '7.3.2 crack · 7.3.3 simplified', v: s.AsReq, tone: '#f59e0b' });
+      if (d && d.AsReq != null) rows.push({ label: '7.3.2 crack · 7.3.4 direct', v: d.AsReq, tone: '#f43f5e' });
+    }
+    const max = Math.max.apply(null, rows.map(x => x.v).concat([1]));
+    $('govBars').innerHTML = rows.map(x =>
+      '<div><div class="flex justify-between text-xs mb-0.5"><span class="text-slate-400">' + x.label +
+      '</span><span class="num text-slate-200">' + fmt(x.v, 0) + '</span></div>' +
+      '<div class="barbg"><div class="barfg" style="width:' + (100 * x.v / max).toFixed(1) + '%;background:' + x.tone + '"></div></div></div>'
+    ).join('');
+  }
+
+  function paintHeroTable(r, dias) {
+    if (!r.crack.active) {
+      const cells = dias.map(d => {
+        const cc = Math.min(1000 * Math.PI * d * d / 4 / r.detailing.AsHMin, r.detailing.sHMax);
+        return { d, cc };
+      });
+      $('heroTable').innerHTML =
+        row('th', 'ø [mm]', cells.map(c => '<b>' + c.d + '</b>')) +
+        row('td', 'A<sub>s</sub> required', cells.map(() => fmt(r.detailing.AsHMin, 0))) +
+        row('td', 'max spacing', cells.map(c => '<b class="text-sky-300">c' + fmt(Math.floor(c.cc / 5) * 5, 0) + '</b>'));
+      $('heroNote').textContent = 'Detailing minimum only. Spacing is additionally capped at c400 by 9.6.3(2).';
+      wireColumns();
+      return;
+    }
+
+    const direct = r.crack.methodEffective === 'direct';
+    const S = dias.map(d => (direct ? r.crack.barsDirect : r.crack.bars).find(b => b.dia === d));
+    const D = dias.map(d => (direct ? r.crack.bars : r.crack.barsDirect).find(b => b.dia === d));
+    const cell = (b, key, dp) => b && b[key] != null ? fmt(b[key], dp) : '<span class="text-slate-600">—</span>';
+    const ccCell = (b) => {
+      if (!b || b.AsReq == null) return '<span class="text-rose-400">n/a</span>';
+      const cc = Math.floor(Math.min(b.ccMax, r.detailing.sHMax) / 5) * 5;
+      const tone = b.build === 'unbuildable' ? 'text-rose-400' : b.build === 'tight' ? 'text-amber-300' : 'text-sky-300';
+      return '<b class="' + tone + '">c' + cc + '</b>';
+    };
+
+    $('heroTable').innerHTML =
+      row('th', 'ø [mm]', dias.map(d => '<b>' + d + '</b>'), dias) +
+      (direct ? '' : row('td', 'φ*<sub>s</sub> needed', S.map(b => cell(b, 'phiStarReq', 1)))) +
+      row('td', 'σ<sub>s</sub> [MPa]', S.map(b => cell(b, 'sigmaS', 0))) +
+      row('td', 'A<sub>s</sub> required [mm²/m]', S.map(b => cell(b, 'AsReq', 0))) +
+      row('td', 'max spacing · ' + (direct ? '7.3.4 direct' : '7.3.3'), S.map(ccCell)) +
+      row('td', 'max spacing · ' + (direct ? '7.3.3' : '7.3.4 direct'), D.map(ccCell)) +
+      row('td', 'verdict', S.map(b => {
+        if (!b || b.status === 'outOfTable') return '<span class="text-rose-400" title="beyond Table 7.2N">bar too large</span>';
+        if (b.status === 'wkOutOfRange') return '<span class="text-slate-600">—</span>';
+        if (b.build === 'unbuildable') return '<span class="text-rose-400">too tight</span>';
+        if (b.build === 'tight') return '<span class="text-amber-300">tight</span>';
+        return '<span class="text-emerald-400">buildable</span>';
+      }));
+
+    const sel = r.crack.bars.find(b => b.dia === state.selectedDia);
+    const selD = r.crack.barsDirect.find(b => b.dia === state.selectedDia);
+    let note = 'Smaller bars are permitted a higher σ<sub>s</sub> by Table 7.2N, so they need <i>less</i> steel — ' +
+      'that is why the required area rises with bar size.';
+    if (sel && selD && sel.AsReq != null && selD.AsReq != null) {
+      note += ' For ø' + state.selectedDia + ' the direct route of 7.3.4 asks for ' + fmt(selD.AsReq, 0) +
+        ' mm²/m against ' + fmt(sel.AsReq, 0) + ' from the simplified route.';
+    }
+    $('heroNote').innerHTML = note;
+    wireColumns();
+  }
+
+  function row(tag, label, cells, dias) {
+    const head = '<' + tag + ' style="text-align:left;color:#7f92ad;font-weight:500">' + label + '</' + tag + '>';
+    return '<tr>' + head + cells.map((c, i) => {
+      const d = dias ? dias[i] : null;
+      const on = (d != null ? d : cellDia(i)) === state.selectedDia;
+      return '<' + tag + ' data-col="' + cellDia(i) + '"' + (on ? ' class="c-pick"' : '') +
+        ' style="cursor:pointer">' + c + '</' + tag + '>';
+    }).join('') + '</tr>';
+  }
+  let COLS = [];
+  function cellDia(i) { return COLS[i]; }
+
+  function wireColumns() {
+    document.querySelectorAll('#heroTable [data-col]').forEach(el => {
+      el.addEventListener('click', () => {
+        state.selectedDia = parseFloat(el.dataset.col);
+        state.diaAuto = false;
+        render();
+      });
+    });
+  }
+
+  function paintMatrix(r, dias) {
+    const spacings = r.constants.SPACINGS;
+    const vertical = state.matrixDir === 'v';
+    const cap = vertical ? r.detailing.sVMax : r.detailing.sHMax;
+
+    const need = dias.map(d => {
+      if (vertical) return r.governing.vertical.As;
+      if (!r.crack.active) return r.detailing.AsHMin;
+      const list = r.crack.methodEffective === 'direct' ? r.crack.barsDirect : r.crack.bars;
+      const b = list.find(x => x.dia === d);
+      if (!b || b.AsReq == null) return null;                 // bar not permitted at this wk
+      return Math.max(b.AsReq, r.detailing.AsHMin);
+    });
+
+    // cheapest (largest) spacing that still works, per column
+    const best = dias.map((d, i) => {
+      if (need[i] == null) return null;
+      let pick = null;
+      for (const s of spacings) {
+        if (s > cap) continue;
+        if (API().area(d, s) >= need[i]) pick = s;
+      }
+      return pick;
+    });
+
+    let html = '<tr><th style="text-align:left">c/c ↓  ø →</th>' +
+      dias.map(d => '<th>' + d + '</th>').join('') + '</tr>';
+    html += '<tr><td style="text-align:left;color:#7f92ad">required</td>' +
+      need.map(v => '<td style="color:#cbd5e1">' + (v == null ? '—' : fmt(v, 0)) + '</td>').join('') + '</tr>';
+
+    for (const s of spacings) {
+      html += '<tr><td style="text-align:left;color:#7f92ad">c' + s + '</td>';
+      dias.forEach((d, i) => {
+        const As = API().area(d, s);
+        let cls = 'c-ok', title = '';
+        if (s > cap) { cls = 'c-cap'; title = 'spacing exceeds the code maximum c' + cap; }
+        else if (need[i] == null) { cls = 'c-veto'; title = 'ø' + d + ' is not permitted at this crack width'; }
+        else if (As >= need[i]) cls = 'c-ok';
+        else if (As >= 0.95 * need[i]) cls = 'c-near';
+        else cls = 'c-bad';
+        const mark = (best[i] === s && s <= cap) ? ' ◇' : '';
+        html += '<td class="' + cls + (best[i] === s && s <= cap ? ' c-pick' : '') + '" title="' + title + '">' +
+          fmt(As, 0) + mark + '</td>';
+      });
+      html += '</tr>';
+    }
+    $('matrix').innerHTML = html;
+  }
+
+  function paintChecks(r) {
+    const icon = { ok: '✓', warn: '!', fail: '✕', info: 'i' };
+    $('checks').innerHTML = r.checks.map(c =>
+      '<div class="flex gap-2"><span class="chk-' + c.status + '" style="width:1em;flex:none">' + icon[c.status] + '</span>' +
+      '<div><div class="text-slate-200">' + esc(c.label) + '</div>' +
+      '<div class="text-slate-500 leading-snug">' + esc(c.detail) + '</div></div></div>'
+    ).join('');
+  }
+
+  function paintWarnings(r) {
+    const items = r.warnings.slice();
+    const cal = r.checks.find(c => c.id === 'tableCalibration');
+    if (cal) items.unshift(cal.detail);
+    $('warnPanel').style.display = items.length ? '' : 'none';
+    $('warnings').innerHTML = items.map(w =>
+      '<div class="border-l-2 border-amber-500/50 pl-2 leading-snug">' + esc(w) + '</div>').join('');
+  }
+
+  // ------------------------------------------------------------------ wiring
+
+  function init() {
+    COLS = API().BAR_DIAMETERS;
+
+    document.querySelectorAll('[data-mode]').forEach(b => b.addEventListener('click', () => {
+      state.mode = b.dataset.mode;
+      document.querySelectorAll('[data-mode]').forEach(x => x.classList.toggle('on', x === b));
+      const preset = { ordinary: 'none', onBase: 'wk030', watertight: 'watertight' }[state.mode];
+      setCrack(preset);
+      render();
+    }));
+
+    document.querySelectorAll('[data-crack]').forEach(b => b.addEventListener('click', () => {
+      setCrack(b.dataset.crack); render();
+    }));
+
+    document.querySelectorAll('[data-method]').forEach(b => b.addEventListener('click', () => {
+      state.method = b.dataset.method;
+      render();
+    }));
+
+    document.querySelectorAll('[data-dir]').forEach(b => b.addEventListener('click', () => {
+      state.matrixDir = b.dataset.dir;
+      document.querySelectorAll('[data-dir]').forEach(x => x.classList.toggle('on', x === b));
+      render();
+    }));
+
+    $('diaPicker').addEventListener('click', (e) => {
+      const b = e.target.closest('[data-dia]');
+      if (!b) return;
+      if (b.dataset.dia === 'auto') { state.diaAuto = true; render(); return; }
+      state.selectedDia = parseFloat(b.dataset.dia);
+      state.diaAuto = false;
+      render();
+    });
+
+    ['t', 'fck', 'fyk', 'layers', 'cover', 'side', 'vdia', 'vcc', 'rtb', 'uplift', 'cnom', 'cmindur',
+      'hD', 'wkCustom', 'kcMode', 'kcCustom', 'kMode', 'age', 'cement', 'wallL', 'wallH', 'epsFree', 'epsCtu']
+      .forEach(id => {
+        const el = $(id);
+        el.addEventListener('input', render);
+        el.addEventListener('change', render);
+      });
+
+    render();
+  }
+
+  function setCrack(v) {
+    state.crackReq = v;
+    document.querySelectorAll('[data-crack]').forEach(x => x.classList.toggle('on', x.dataset.crack === v));
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/concrete_wall_minimum_reinforcement/test.js
+++ b/concrete_wall_minimum_reinforcement/test.js
@@ -1,0 +1,99 @@
+// Verification vectors for wall_min_reinf_api.js.  Run:  node test.js
+const A = require('./wall_min_reinf_api.js');
+let pass=0, fail=0;
+const near=(a,b,tol)=>a!=null&&Math.abs(a-b)<=tol;
+function t(name, got, want, tol){ const ok=near(got,want,tol); ok?pass++:fail++;
+  console.log((ok?'PASS':'FAIL')+'  '+name+'  got='+(got==null?'null':(+got).toFixed(2))+' want='+want); }
+
+// 1 base case
+let r = A.calculate({t:350, fck:35, exposureSide:'exterior', vBar:{dia:12,spacing:250}, crackReq:'none'});
+t('fctm B35', r.material.fctm, 3.21, 0.01);
+t('AsHMin (exact fctm 3.2098)', r.detailing.AsHMin, 674.1, 1);
+t('AsVMin', r.detailing.AsVMin, 350, 1);
+t('AsVProv', r.detailing.AsVProv, 452.39, 0.1);
+t('sVMax t350', r.detailing.sVMax, 400, 0.1);
+
+// 2 sheet parity: kc=1, sigma=240 -> 2333
+const parity = 1*1*3.2*350000/240/2;
+t('sheet C22 formula', parity, 2333.3, 1);
+
+// 3 wk0.3 ø16
+r = A.calculate({t:350, fck:35, cover:35, crackReq:'wk030', selectedDia:16, vBar:{dia:12,spacing:250}});
+const b16 = r.crack.bars.find(b=>b.dia===16);
+t('phi*req o16', b16.phiStarReq, 14.25, 0.05);
+t('sigmaS o16', b16.sigmaS, 257.5, 2);
+t('AsReq o16', b16.AsReq, 2175, 10);
+t('ccMax o16', b16.ccUncapped, 92, 2);
+const b8 = r.crack.bars.find(b=>b.dia===8);
+t('sigmaS o8', b8.sigmaS, 391, 3);
+t('AsFloor', r.crack.AsFloor, 1120, 5);
+
+// 4 Ramboll culvert t=240 B45
+r = A.calculate({t:240, fck:45, exposureSide:'exterior', vBar:{dia:16,spacing:200}, crackReq:'none'});
+t('culvert naLeg', r.detailing.naLeg, 547.2, 1);
+t('culvert AsVMin/layer', r.detailing.AsVMin, 240, 1);
+t('culvert AsVMax', r.detailing.AsVMax, 9600, 1);
+
+// 5 retaining wall t=400 B35
+r = A.calculate({t:400, fck:35, exposureSide:'exterior', vBar:{dia:16,spacing:200}, crackReq:'none'});
+t('rw naLeg (fctm 3.21)', r.detailing.naLeg, 770, 2);
+t('rw AsVMin/layer', r.detailing.AsVMin, 400, 1);
+
+// 6 single layer t=200
+r = A.calculate({t:200, fck:35, layers:1, crackReq:'wk030', selectedDia:10, vBar:{dia:12,spacing:200}});
+const s8 = r.crack.bars.find(b=>b.dia===8);
+const s10 = r.crack.bars.find(b=>b.dia===10);
+console.log((s10.status==='outOfTable'?'PASS':'FAIL')+'  single layer o10 outOfTable  got='+s10.status); s10.status==='outOfTable'?pass++:fail++;
+console.log((s8.build==='unbuildable'?'PASS':'FAIL')+'  single layer o8 unbuildable  got='+s8.build+' cc='+(s8.ccUncapped||0).toFixed(1)); s8.build==='unbuildable'?pass++:fail++;
+console.log((r.governing.horizontal.blocked?'PASS':'FAIL')+'  blocked o10 does not fall back to detailing  As='+r.governing.horizontal.As); r.governing.horizontal.blocked?pass++:fail++;
+
+// 7 t=100 spacing cap
+r = A.calculate({t:100, fck:35, vBar:{dia:8,spacing:200}, crackReq:'none'});
+t('sVMax t100', r.detailing.sVMax, 300, 0.1);
+
+// 8 fck 40 no zero
+t('fctm B40', A.fctmOf(40), 3.51, 0.01);
+
+// 9 early age
+r = A.calculate({t:350, fck:35, crackAgeDays:3, cementClass:'N', crackReq:'wk030', vBar:{dia:12,spacing:250}});
+t('fctEff 3d', r.material.fctEff, 1.92, 0.02);
+
+// 10 Table L.1
+r = A.calculate({t:250, wallL:36000, wallH:3000, crackReq:'wk030', vBar:{dia:12,spacing:250}});
+t('L/H 12 Rtop', r.zone.tableL1.Rtop, 0.5, 0.001);
+console.log('  L/H12 note='+r.zone.tableL1.note+' height='+r.zone.tableL1.height);
+r = A.calculate({t:350, wallL:6000, wallH:3000, crackReq:'wk030', vBar:{dia:12,spacing:250}});
+t('L/H2 zone height (Rcrit=0.3125)', r.zone.tableL1.height, 1125, 5);
+t('3t', r.zone.practice, 1050, 1);
+
+// 11 watertight
+r = A.calculate({mode:'watertight', t:300, fck:35, crackReq:'watertight', hD:1200, selectedDia:12, vBar:{dia:12,spacing:200}});
+console.log('  watertight wk='+r.crack.wk.toFixed(3)+' src='+r.crack.wkSource);
+r = A.calculate({mode:'watertight', t:300, fck:35, crackReq:'watertight', hD:6000, selectedDia:12, vBar:{dia:12,spacing:200}});
+console.log('  deep tank wk='+r.crack.wk.toFixed(3)+'  simplified o12 status='+r.crack.bars.find(b=>b.dia===12).status
+  +'  direct o12 As='+ (r.crack.barsDirect.find(b=>b.dia===12).AsReq||0).toFixed(0));
+
+// 12 direct vs simplified on the base case
+r = A.calculate({t:350, fck:35, cover:35, crackReq:'wk030', selectedDia:16, vBar:{dia:12,spacing:250}});
+const d16 = r.crack.barsDirect.find(b=>b.dia===16);
+console.log('  o16 simplified As='+b16.AsReq.toFixed(0)+' cc='+b16.ccUncapped.toFixed(0)
+  +'   direct As='+d16.AsReq.toFixed(0)+' cc='+d16.ccUncapped.toFixed(0)+' srMax='+d16.srMax.toFixed(0));
+
+// 13 NA uplift
+r = A.calculate({t:350, fck:35, crackReq:'wk030', naCoverUplift:{on:true,cnom:35,cminDur:25}, vBar:{dia:12,spacing:250}});
+t('NA uplift wk', r.crack.wk, 0.39, 0.001);
+r = A.calculate({t:350, fck:35, crackReq:'wk030', naCoverUplift:{on:true,cnom:60,cminDur:25}, vBar:{dia:12,spacing:250}});
+t('NA uplift capped 1.3', r.crack.wk, 0.39, 0.001);
+
+// 14 single layer detailing doubling
+r = A.calculate({t:200, fck:35, layers:1, exposureSide:'exterior', vBar:{dia:12,spacing:200}, crackReq:'none'});
+t('1-layer AsVMin=full', r.detailing.AsVMin, 400, 1);
+t('1-layer AsHMin=2*naLeg', r.detailing.AsHMin, 2*0.3*200000*3.21/500, 5);
+
+// 15 interior wall
+r = A.calculate({t:350, fck:35, exposureSide:'interior', vBar:{dia:12,spacing:250}, crackReq:'none'});
+t('interior naLeg', r.detailing.naLeg, 337.0, 1);
+t('interior AsHMin', r.detailing.AsHMin, 337.0, 1);
+
+console.log('\n'+pass+' passed, '+fail+' failed');
+process.exit(fail?1:0);

--- a/concrete_wall_minimum_reinforcement/wall_min_reinf_api.js
+++ b/concrete_wall_minimum_reinforcement/wall_min_reinf_api.js
@@ -1,0 +1,512 @@
+/**
+ * Minimum reinforcement for concrete walls — pure calculation layer.
+ *
+ * NS-EN 1992-1-1 §7.3.2, §7.3.3, §7.3.4, §9.6 with the Norwegian National Annex,
+ * plus NS-EN 1992-3 for watertight walls.
+ *
+ * No DOM access, no side effects. See SPEC.md for the contract this implements.
+ */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  root.WallMinReinf = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  const ES = 200000;                                     // steel modulus [MPa]
+  const BAR_DIAMETERS = [8, 10, 12, 16, 20, 25, 32];
+  const SPACINGS = [75, 100, 125, 150, 200, 250, 300, 400];
+
+  /** EC2 Table 7.2N — maximum bar diameter phi*s [mm] for crack control. */
+  const T72N_SIGMA = [160, 200, 240, 280, 320, 360, 400, 450];
+  const T72N = {
+    0.4: [40, 32, 20, 16, 12, 10, 8, 6],
+    0.3: [32, 25, 16, 12, 10, 8, 6, 5],
+    0.2: [25, 16, 12, 8, 6, 5, 4, null]
+  };
+  const T72N_WK = [0.2, 0.3, 0.4];
+
+  /** EN 1992-3 Table L.1 — restraint at the top of a wall cast on a base. */
+  const TABLE_L1 = [[1, 0], [2, 0], [3, 0.05], [4, 0.30], [8, 0.50]];
+  const R_BASE = 0.5;
+
+  const CEMENT_S = { R: 0.20, N: 0.25, S: 0.38 };
+
+  const area = (dia, spacing) => (1000 / spacing) * Math.PI * dia * dia / 4;
+  const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+  const lerp = (x, x0, x1, y0, y1) => (x1 === x0 ? y0 : y0 + (x - x0) / (x1 - x0) * (y1 - y0));
+
+  // ---------------------------------------------------------------- materials
+
+  /** EC2 Table 3.1 — mean axial tensile strength. Matches EC2ConcreteUtils.calculateFctm. */
+  function fctmOf(fck) {
+    return fck <= 50 ? 0.30 * Math.pow(fck, 2 / 3) : 2.12 * Math.log(1 + (fck + 8) / 10);
+  }
+
+  /** EC2 (3.2) + (3.4) — tensile strength at age t. */
+  function fctmAt(fck, days, cementClass) {
+    const fctm = fctmOf(fck);
+    if (!days || days >= 28) return { value: fctm, betaCc: 1 };
+    const s = CEMENT_S[cementClass] || CEMENT_S.N;
+    const betaCc = Math.exp(s * (1 - Math.sqrt(28 / days)));
+    return { value: Math.pow(betaCc, 1) * fctm, betaCc };            // alpha = 1 for t < 28 d
+  }
+
+  const ecmOf = (fck) => 22000 * Math.pow((fck + 8) / 10, 0.3);
+
+  // ------------------------------------------------------- Table 7.2N inverse
+
+  /**
+   * Build the phi*s(sigma_s) curve at an arbitrary wk by interpolating between the
+   * tabulated columns. Rows where a bracketing column has no value are dropped.
+   */
+  function t72nColumn(wk) {
+    if (wk < T72N_WK[0] - 1e-9 || wk > T72N_WK[T72N_WK.length - 1] + 1e-9) return null;
+    let lo = T72N_WK[0], hi = T72N_WK[T72N_WK.length - 1];
+    for (let i = 0; i < T72N_WK.length - 1; i++) {
+      if (wk >= T72N_WK[i] - 1e-9 && wk <= T72N_WK[i + 1] + 1e-9) { lo = T72N_WK[i]; hi = T72N_WK[i + 1]; break; }
+    }
+    const a = T72N[lo], b = T72N[hi];
+    const pts = [];
+    for (let i = 0; i < T72N_SIGMA.length; i++) {
+      if (a[i] == null || b[i] == null) continue;
+      pts.push({ sigma: T72N_SIGMA[i], phi: lo === hi ? a[i] : lerp(wk, lo, hi, a[i], b[i]) });
+    }
+    return pts;
+  }
+
+  /**
+   * Invert Table 7.2N: the steel stress permitted for a bar of adjusted size phiReq.
+   * Never clamps silently — a request below the table's stress range is refused, because
+   * pinning sigma_s at 160 MPa there would understate the reinforcement.
+   */
+  function sigmaFromTable(phiReq, wk, fyk) {
+    const pts = t72nColumn(wk);
+    if (!pts || pts.length < 2) return { status: 'wkOutOfRange' };
+    if (phiReq > pts[0].phi) return { status: 'outOfTable' };
+    const last = pts[pts.length - 1];
+    if (phiReq <= last.phi) {
+      return { status: 'capped', sigmaS: Math.min(last.sigma, fyk) };
+    }
+    for (let i = 0; i < pts.length - 1; i++) {
+      if (phiReq <= pts[i].phi && phiReq >= pts[i + 1].phi) {
+        const s = lerp(phiReq, pts[i].phi, pts[i + 1].phi, pts[i].sigma, pts[i + 1].sigma);
+        return { status: 'ok', sigmaS: Math.min(s, fyk) };
+      }
+    }
+    return { status: 'outOfTable' };
+  }
+
+  // ------------------------------------------------------------ buildability
+
+  function buildability(ccMax) {
+    if (!isFinite(ccMax) || ccMax <= 0) return 'unbuildable';
+    if (ccMax < 75) return 'unbuildable';
+    if (ccMax < 100) return 'tight';
+    return 'ok';
+  }
+
+  // -------------------------------------------------------------- main entry
+
+  function calculate(raw) {
+    const inp = normalise(raw);
+    const warnings = [];
+    const checks = [];
+
+    const t = inp.t;
+    const Ac = 1000 * t;
+    const layers = inp.layers;
+
+    // --- materials
+    const fctm = fctmOf(inp.fck);
+    const { value: fctEff, betaCc } = fctmAt(inp.fck, inp.crackAgeDays, inp.cementClass);
+    const Ecm = ecmOf(inp.fck);
+    const alphaE = ES / Ecm;
+
+    if (inp.crackAgeDays < 28) {
+      warnings.push('fct,eff is taken as fctm(' + inp.crackAgeDays + ' d) = ' + fctEff.toFixed(2) +
+        ' MPa per 7.3.2(2). Several National Annexes impose a floor on fct,eff for early-age ' +
+        'restraint — confirm against NA:2010 before relying on this reduction.');
+    }
+
+    // --- detailing, §9.6 + NA.9.6.3
+    const AsVMin = 0.002 * Ac / layers;
+    const AsVMax = 0.04 * Ac;
+    const sVMax = Math.min(3 * t, 400);
+    const sHMax = 400;
+    const AsVProv = area(inp.vBar.dia, inp.vBar.spacing);
+    const kNA = inp.kNaOverride != null ? inp.kNaOverride : (inp.exposureSide === 'exterior' ? 0.30 : 0.15);
+    const naLeg = kNA * Ac * fctm / inp.fyk;
+    const quarterLeg = 0.25 * AsVProv;
+    const AsHMin = layers === 2
+      ? Math.max(quarterLeg, naLeg)
+      : Math.max(quarterLeg, 2 * naLeg);
+    const AsHMinLeg = (layers === 2 ? naLeg : 2 * naLeg) >= quarterLeg ? 'NA.9.6.3' : '25 % of As,v';
+
+    const AsVTotal = AsVProv * layers;
+    const linksNeeded = AsVTotal > 0.02 * Ac;
+    const linksWaived = inp.vBar.dia <= 16 && inp.cover > 2 * inp.vBar.dia;
+
+    // --- crack control, §7.3.2
+    const wkInfo = targetWk(inp, t);
+    const kc = inp.kcMode === 'pureTension' ? 1.0 : inp.kcMode === 'house' ? 0.6 : inp.kcCustom;
+    const k = inp.kMode === 'external' ? 1.0 : clamp(lerp(t, 300, 800, 1.0, 0.65), 0.65, 1.0);
+    const Act = Ac;
+    const AsFloor = kc * k * fctEff * Act / (inp.fyk * layers);
+    const crackActive = inp.crackReq !== 'none' && wkInfo.wk != null;
+
+    const bars = [];
+    const barsDirect = [];
+    if (crackActive) {
+      for (const dia of BAR_DIAMETERS) {
+        bars.push(simplifiedBar(dia, inp, { t, Act, kc, k, fctEff, AsFloor, wk: wkInfo.wk, sHMax }));
+        barsDirect.push(directBar(dia, inp, { t, Act, kc, k, fctEff, alphaE, AsFloor, wk: wkInfo.wk, sHMax }));
+      }
+    }
+
+    // --- what governs, for the selected bar
+    const tableCovers = crackActive && wkInfo.wk >= 0.2 - 1e-9 && wkInfo.wk <= 0.4 + 1e-9;
+    const methodEffective = (crackActive && !tableCovers) ? 'direct' : inp.method;
+    if (crackActive && !tableCovers) {
+      warnings.push('wk = ' + fmt(wkInfo.wk, 3) + ' mm lies outside Table 7.2N, which only spans ' +
+        '0,20 to 0,40 mm. The simplified route of 7.3.3 cannot answer here, so the tool has switched ' +
+        'to the direct calculation of 7.3.4. EN 1992-3 Figure 7.103N extends the tabulated route below ' +
+        '0,20 mm; it is not reproduced here.');
+    }
+    const source = methodEffective === 'direct' ? barsDirect : bars;
+    const alt = methodEffective === 'direct' ? bars : barsDirect;
+    const sel = source.find(b => b.dia === inp.selectedDia) || source[0] || null;
+    const selAlt = alt.find(b => b.dia === inp.selectedDia) || null;
+    const blocked = crackActive && sel && (sel.status === 'outOfTable' || sel.status === 'unreachable' || sel.status === 'wkOutOfRange');
+    const crackAs = sel && !blocked ? sel.AsReq : null;
+
+    const detailCc = AsHMin > 0 ? Math.min(1000 * Math.PI * Math.pow(inp.selectedDia, 2) / 4 / AsHMin, sHMax) : sHMax;
+    let hGov;
+    if (blocked) {
+      // The chosen bar cannot satisfy the crack requirement by this route. Reporting the
+      // detailing minimum here would read as an answer; it is not one.
+      hGov = { As: null, clause: 'no valid answer for ø' + inp.selectedDia, dia: inp.selectedDia,
+               ccMax: null, blocked: true, blockReason: sel.status, detailingAs: AsHMin };
+    } else if (crackAs != null && crackAs > AsHMin) {
+      hGov = { As: crackAs, clause: '7.3.2 (crack)', dia: sel.dia, ccMax: sel.ccMax,
+               ratio: crackAs / AsHMin, blocked: false };
+    } else {
+      hGov = { As: AsHMin, clause: AsHMinLeg, dia: inp.selectedDia, ccMax: detailCc, ratio: 1, blocked: false };
+    }
+    hGov.altAs = selAlt && selAlt.AsReq != null ? selAlt.AsReq : null;
+    hGov.altRoute = inp.method === 'direct' ? 'simplified' : 'direct';
+
+    const vCrack = inp.restrainedTopBottom && crackActive && crackAs != null ? crackAs : null;
+    const vGov = vCrack != null && vCrack > AsVMin
+      ? { As: vCrack, clause: '7.3.2 (crack, restrained top and bottom)' }
+      : { As: AsVMin, clause: '9.6.2(1)' };
+
+    // --- restrained zone height
+    const zone = zoneHeight(inp, t);
+
+    // --- checks
+    pushChecks(checks, {
+      inp, t, Ac, layers, AsVMin, AsVMax, AsVProv, AsVTotal, sVMax, sHMax,
+      AsHMin, linksNeeded, linksWaived, crackActive, wkInfo, sel, selAlt, hGov, AsFloor, zone,
+      methodEffective
+    });
+
+    if (crackActive && wkInfo.wk < 0.2) {
+      warnings.push('wk = ' + wkInfo.wk.toFixed(3) + ' mm is below the range of Table 7.2N. ' +
+        'The simplified route of 7.3.3 cannot answer this — use the direct calculation to 7.3.4.');
+    }
+    if (crackActive && layers === 1) {
+      warnings.push('A single central layer sits t/2 from the surface, so eq. (7.7N) penalises it ' +
+        'heavily. Crack control under edge restraint is normally not achievable in one layer — ' +
+        'use two layers, or provide movement joints (EN 1992-3 Table N.1(b)).');
+    }
+
+    return {
+      ok: true,
+      inputs: inp,
+      material: { fctm, fctEff, Ecm, alphaE, betaCc },
+      detailing: {
+        Ac, AsVMin, AsVMax, sVMax, sHMax, AsVProv, AsVTotal, kNA, naLeg, quarterLeg,
+        AsHMin, AsHMinLeg, links: { needed: linksNeeded, waived: linksWaived }
+      },
+      crack: {
+        active: crackActive, wk: wkInfo.wk, wkSource: wkInfo.source,
+        kc, k, Act, AsFloor, bars, barsDirect, methodEffective, tableCovers
+      },
+      governing: { horizontal: hGov, vertical: vGov },
+      zone,
+      checks,
+      warnings,
+      constants: { BAR_DIAMETERS, SPACINGS }
+    };
+  }
+
+  // ------------------------------------------------------------- sub-routines
+
+  function targetWk(inp, t) {
+    switch (inp.crackReq) {
+      case 'none': return { wk: null, source: 'crack control not required' };
+      case 'wk040': return { wk: 0.40, source: 'wk = 0,40 mm (X0)' };
+      case 'wk020': return { wk: 0.20, source: 'wk = 0,20 mm' };
+      case 'custom': return { wk: inp.wkCustom, source: 'wk = ' + fmt(inp.wkCustom, 3) + ' mm (user)' };
+      case 'watertight': {
+        const ratio = inp.hD / t;
+        const wk = ratio <= 5 ? 0.20 : ratio >= 35 ? 0.05 : lerp(ratio, 5, 35, 0.20, 0.05);
+        return { wk, source: 'EN 1992-3 Class 1, hD/h = ' + fmt(ratio, 1) + ' → wk1 = ' + fmt(wk, 3) + ' mm' };
+      }
+      case 'wk030':
+      default: {
+        if (inp.naCoverUplift.on) {
+          const kcc = clamp(inp.naCoverUplift.cnom / inp.naCoverUplift.cminDur, 1.0, 1.3);
+          return { wk: 0.30 * kcc, source: 'NA.7.3.1(5): 0,30·kc with kc = ' + fmt(kcc, 2) };
+        }
+        return { wk: 0.30, source: 'wk = 0,30 mm (XC/XD/XS)' };
+      }
+    }
+  }
+
+  /** 7.3.3(2) — Table 7.2N with the eq. (7.7N) / (7.122) size adjustment. */
+  function simplifiedBar(dia, inp, ctx) {
+    const hMinusD = inp.layers === 2 ? inp.cover + dia / 2 : ctx.t / 2;
+    const denom = inp.mode === 'watertight' ? 10 : 8;
+    const fAdj = (ctx.fctEff / 2.9) * ctx.t / (denom * hMinusD);
+    const phiStarReq = dia / fAdj;
+    const inv = sigmaFromTable(phiStarReq, ctx.wk, inp.fyk);
+
+    if (inv.status === 'outOfTable' || inv.status === 'wkOutOfRange') {
+      return { dia, phiStarReq, sigmaS: null, AsReq: null, ccMax: null, status: inv.status, build: null, route: 'simplified' };
+    }
+    const AsReq = Math.max(ctx.kc * ctx.k * ctx.fctEff * ctx.Act / (inv.sigmaS * inp.layers), ctx.AsFloor);
+    const raw = 1000 * Math.PI * dia * dia / 4 / AsReq;
+    const ccMax = Math.min(raw, ctx.sHMax);
+    return {
+      dia, phiStarReq, sigmaS: inv.sigmaS, AsReq, ccMax, ccUncapped: raw,
+      status: inv.status, build: buildability(raw),
+      floorGoverns: AsReq <= ctx.AsFloor * 1.0001, route: 'simplified'
+    };
+  }
+
+  /** 7.3.4 — direct crack width calculation, section fully in tension. */
+  function directBar(dia, inp, ctx) {
+    const hMinusD = inp.layers === 2 ? inp.cover + dia / 2 : ctx.t / 2;
+    const cEff = inp.layers === 2 ? inp.cover : (ctx.t - dia) / 2;
+    const hcEf = Math.min(2.5 * hMinusD, ctx.t / 2);
+    const AcEff = 1000 * hcEf;
+
+    const wkOf = (As) => {
+      const sigmaS = Math.min(ctx.kc * ctx.k * ctx.fctEff * ctx.Act / (As * inp.layers), inp.fyk);
+      const rho = As / AcEff;
+      const srMax = 3.4 * cEff + 0.8 * 1.0 * 0.425 * dia / rho;
+      const eps = Math.max(
+        (sigmaS - 0.4 * ctx.fctEff / rho * (1 + ctx.alphaE * rho)) / ES,
+        0.6 * sigmaS / ES
+      );
+      return { wk: srMax * eps, sigmaS, srMax, rho };
+    };
+
+    const lo = ctx.AsFloor, hi = 20000;
+    if (wkOf(lo).wk <= ctx.wk) {
+      const r = wkOf(lo);
+      const raw = 1000 * Math.PI * dia * dia / 4 / lo;
+      return {
+        dia, sigmaS: r.sigmaS, AsReq: lo, ccMax: Math.min(raw, ctx.sHMax), ccUncapped: raw,
+        srMax: r.srMax, status: 'ok', build: buildability(raw), floorGoverns: true, route: 'direct'
+      };
+    }
+    if (wkOf(hi).wk > ctx.wk) {
+      return { dia, sigmaS: null, AsReq: null, ccMax: null, status: 'unreachable', build: null, route: 'direct' };
+    }
+    let a = lo, b = hi;
+    for (let i = 0; i < 60; i++) {
+      const m = (a + b) / 2;
+      if (wkOf(m).wk > ctx.wk) a = m; else b = m;
+    }
+    const As = b;
+    const r = wkOf(As);
+    const raw = 1000 * Math.PI * dia * dia / 4 / As;
+    const srLimit = 5 * (cEff + dia / 2);
+    return {
+      dia, sigmaS: r.sigmaS, AsReq: As, ccMax: Math.min(raw, ctx.sHMax), ccUncapped: raw,
+      srMax: r.srMax, status: 'ok', build: buildability(raw),
+      floorGoverns: false, wideSpacing: raw > srLimit, srLimit, route: 'direct'
+    };
+  }
+
+  /** EN 1992-3 Annex L / Annex M — height over which edge restraint actually cracks. */
+  function zoneHeight(inp, t) {
+    const practice = 3 * t;
+    if (!inp.wallL || !inp.wallH) return { practice, tableL1: null };
+    const LH = inp.wallL / inp.wallH;
+    let Rtop;
+    if (LH <= 1) Rtop = 0;
+    else if (LH >= 8) Rtop = 0.5;
+    else {
+      Rtop = 0.5;
+      for (let i = 0; i < TABLE_L1.length - 1; i++) {
+        const [x0, y0] = TABLE_L1[i], [x1, y1] = TABLE_L1[i + 1];
+        if (LH >= x0 && LH <= x1) { Rtop = lerp(LH, x0, x1, y0, y1); break; }
+      }
+    }
+    const Rcrit = inp.epsCtu / inp.epsFree;
+    if (Rcrit >= R_BASE) {
+      return { practice, tableL1: { LH, Rtop, Rcrit, height: 0, note: 'noCracking' } };
+    }
+    if (Rtop >= Rcrit) {
+      return { practice, tableL1: { LH, Rtop, Rcrit, height: inp.wallH, note: 'fullHeight' } };
+    }
+    const frac = clamp((R_BASE - Rcrit) / (R_BASE - Rtop), 0, 1);
+    return { practice, tableL1: { LH, Rtop, Rcrit, height: frac * inp.wallH, frac, note: 'partial' } };
+  }
+
+  function pushChecks(checks, c) {
+    const add = (id, label, status, detail) => checks.push({ id, label, status, detail });
+
+    if (c.inp.wallL) {
+      const ratio = c.inp.wallL / c.t;
+      add('scope', 'Wall definition, 9.6.1(1)', ratio >= 4 ? 'ok' : 'fail',
+        'length / thickness = ' + fmt(ratio, 1) + (ratio >= 4 ? ' ≥ 4' : ' < 4 — §9.6 does not apply, design as a column'));
+    } else {
+      add('scope', 'Wall definition, 9.6.1(1)', 'info',
+        '§9.6 applies where length / thickness ≥ 4. A wall governed by out-of-plane bending follows the slab rules of §9.3 instead.');
+    }
+
+    add('vspacing', 'Vertical bar spacing, 9.6.2(3)',
+      c.inp.vBar.spacing <= c.sVMax ? 'ok' : 'fail',
+      'c' + c.inp.vBar.spacing + ' vs max ' + fmt(c.sVMax, 0) + ' mm = min(3t, 400)');
+
+    add('vmin', 'Vertical minimum, 9.6.2(1)',
+      c.AsVProv >= c.AsVMin ? 'ok' : 'fail',
+      'provided ' + fmt(c.AsVProv, 0) + ' vs required ' + fmt(c.AsVMin, 0) + ' mm²/m per layer');
+
+    add('vmax', 'Vertical maximum, 9.6.2(1)',
+      c.AsVTotal <= c.AsVMax ? 'ok' : 'fail',
+      fmt(c.AsVTotal, 0) + ' vs 0,04·Ac = ' + fmt(c.AsVMax, 0) + ' mm²/m (0,08·Ac at laps)');
+
+    add('hspacing', 'Horizontal bar spacing, 9.6.3(2)',
+      c.hGov.ccMax <= c.sHMax ? 'ok' : 'warn',
+      'required c' + fmt(c.hGov.ccMax, 0) + ', code maximum c400');
+
+    if (c.linksNeeded) {
+      add('links', 'Transverse links, 9.6.4(1)', 'warn',
+        'vertical steel exceeds 0,02·Ac — links to §9.5.3 are required');
+    } else if (c.layers === 2) {
+      add('links', 'Transverse links, 9.6.4(2)', c.linksWaived ? 'ok' : 'warn',
+        c.linksWaived
+          ? 'waived: ø ≤ 16 mm with cover > 2ø'
+          : '4 links/m² required where the main reinforcement is nearest the faces, unless ø ≤ 16 mm with cover > 2ø');
+    }
+
+    if (c.crackActive && c.sel) {
+      if (c.sel.status === 'outOfTable') {
+        add('crack', 'Crack control, 7.3.3(2)', 'fail',
+          'ø' + c.sel.dia + ' needs a φ*s beyond Table 7.2N. No simplified answer exists — calculate directly to 7.3.4 or use a smaller bar.');
+      } else if (c.sel.status === 'unreachable') {
+        add('crack', 'Crack control, 7.3.4', 'fail',
+          'wk = ' + fmt(c.wkInfo.wk, 2) + ' mm is not reachable with ø' + c.sel.dia + ' at any spacing.');
+      } else {
+        add('crack', 'Crack control, ' + (c.methodEffective === 'direct' ? '7.3.4' : '7.3.3(2)'),
+          c.sel.build === 'unbuildable' ? 'fail' : c.sel.build === 'tight' ? 'warn' : 'ok',
+          'ø' + c.sel.dia + ' at σs = ' + fmt(c.sel.sigmaS, 0) + ' MPa needs c' + fmt(c.sel.ccUncapped, 0) +
+          (c.sel.build === 'unbuildable' ? ' — below 75 mm, not buildable' :
+            c.sel.build === 'tight' ? ' — tight but buildable' : ''));
+      }
+      if (c.methodEffective === 'simplified' && c.selAlt && c.selAlt.AsReq != null &&
+          c.sel.AsReq != null && c.selAlt.AsReq > c.sel.AsReq * 1.05) {
+        add('tableCalibration', 'Table 7.2N is calibrated for bending', 'warn',
+          'Note 1 to Table 7.2N states the table assumes k2 = 0,5, kc = 0,4 and hcr = 0,5h — a section ' +
+          'in bending. A wall cracking under edge restraint is in uniform tension, where k2 = 1,0 and ' +
+          'hcr = h. Eq. (7.7N) rescales the bar size for that, but it does not restore k2 inside sr,max. ' +
+          'Calculating directly to 7.3.4 with k2 = 1,0 gives ' + fmt(c.selAlt.AsReq, 0) + ' mm²/m, ' +
+          fmt((c.selAlt.AsReq / c.sel.AsReq - 1) * 100, 0) + ' % more. 7.3.1(9) makes the two routes ' +
+          'alternatives, so both are compliant — but for restraint the direct route is the truthful one.');
+      }
+      const AsTot = c.sel.AsReq != null ? c.sel.AsReq * c.layers : null;
+      if (AsTot != null && AsTot > 0.04 * c.Ac) {
+        add('congestion', 'Reinforcement ratio', 'fail',
+          fmt(c.sel.AsReq, 0) + ' mm\u00b2/m per face is ' + fmt(100 * AsTot / c.Ac, 1) +
+          ' % of the section across both faces, past the 4 % that 9.6.2(1) allows for the vertical ' +
+          'steel in both faces together. A crack requirement this tight is not a reinforcement ' +
+          'problem: EN 1992-3 7.3.1(111) expects liners or prestress for Tightness Class 2 and 3, ' +
+          'and Table N.1(b) offers movement joints as the alternative.');
+      } else if (AsTot != null && AsTot > 0.02 * c.Ac) {
+        add('congestion', 'Reinforcement ratio', 'warn',
+          fmt(100 * AsTot / c.Ac, 1) + ' % of the section across both faces. Check bar spacing against ' +
+          '8.2 clear distances and think about whether movement joints would be cheaper.');
+      }
+      if (c.sel.floorGoverns) {
+        add('floor', 'Yield floor, 7.3.2(2)', 'info',
+          'the crack width is not what governs here — As is at the floor ' + fmt(c.AsFloor, 0) +
+          ' mm²/m at which the steel would reach fyk on first cracking');
+      }
+    }
+
+    if (c.zone.tableL1) {
+      const z = c.zone.tableL1;
+      const status = z.note === 'noCracking' ? 'ok' : z.height > c.zone.practice * 1.05 ? 'warn' : 'ok';
+      const detail = z.note === 'noCracking'
+        ? 'R_crit = ' + fmt(z.Rcrit, 2) + ' exceeds the 0,50 base restraint — no restraint cracking predicted'
+        : 'L/H = ' + fmt(z.LH, 1) + ' → R = 0,50 at base, ' + fmt(z.Rtop, 2) + ' at top; cracked zone ' +
+          fmt(z.height, 0) + ' mm vs 3t = ' + fmt(c.zone.practice, 0) + ' mm' +
+          (z.height > c.zone.practice * 1.05 ? ' — 3t is unconservative for this geometry' : '');
+      add('zone', 'Restrained zone, EN 1992-3 Table L.1', status, detail);
+    }
+  }
+
+  // ----------------------------------------------------------------- helpers
+
+  function fmt(v, dp) {
+    if (v == null || !isFinite(v)) return '—';
+    return v.toFixed(dp).replace('.', ',');
+  }
+
+  function num(v, dflt) {
+    const n = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
+    return isFinite(n) ? n : dflt;
+  }
+
+  function normalise(r) {
+    r = r || {};
+    const layers = r.layers === 1 ? 1 : 2;
+    return {
+      mode: r.mode || 'onBase',
+      restrainedTopBottom: !!r.restrainedTopBottom,
+      t: clamp(num(r.t, 350), 50, 3000),
+      fck: clamp(num(r.fck, 35), 12, 90),
+      fyk: clamp(num(r.fyk, 500), 200, 700),
+      layers,
+      cover: clamp(num(r.cover, 35), 10, 200),
+      exposureSide: r.exposureSide === 'interior' ? 'interior' : 'exterior',
+      kNaOverride: r.kNaOverride == null || r.kNaOverride === '' ? null : num(r.kNaOverride, null),
+      vBar: {
+        dia: clamp(num(r.vBar && r.vBar.dia, 12), 5, 40),
+        spacing: clamp(num(r.vBar && r.vBar.spacing, 250), 40, 600)
+      },
+      crackReq: r.crackReq || 'wk030',
+      wkCustom: clamp(num(r.wkCustom, 0.30), 0.01, 1.0),
+      naCoverUplift: {
+        on: !!(r.naCoverUplift && r.naCoverUplift.on),
+        cnom: num(r.naCoverUplift && r.naCoverUplift.cnom, 35),
+        cminDur: Math.max(1, num(r.naCoverUplift && r.naCoverUplift.cminDur, 25))
+      },
+      hD: clamp(num(r.hD, 2000), 0, 100000),
+      kcMode: r.kcMode || 'pureTension',
+      kcCustom: clamp(num(r.kcCustom, 1.0), 0.05, 1.0),
+      kMode: r.kMode === 'ec2h' ? 'ec2h' : 'external',
+      crackAgeDays: clamp(num(r.crackAgeDays, 28), 1, 28),
+      cementClass: CEMENT_S[r.cementClass] ? r.cementClass : 'N',
+      method: r.method === 'direct' ? 'direct' : 'simplified',
+      selectedDia: BAR_DIAMETERS.includes(num(r.selectedDia, 16)) ? num(r.selectedDia, 16) : 16,
+      wallL: r.wallL ? num(r.wallL, null) : null,
+      wallH: r.wallH ? num(r.wallH, null) : null,
+      epsFree: num(r.epsFree, 320e-6),
+      epsCtu: num(r.epsCtu, 100e-6)
+    };
+  }
+
+  return {
+    calculate,
+    // exposed for tests and for the UI's matrix
+    fctmOf, fctmAt, ecmOf, sigmaFromTable, t72nColumn, area, buildability,
+    BAR_DIAMETERS, SPACINGS, T72N, T72N_SIGMA, TABLE_L1, fmt
+  };
+});

--- a/concrete_wall_minimum_reinforcement/wall_min_reinf_api.js
+++ b/concrete_wall_minimum_reinforcement/wall_min_reinf_api.js
@@ -123,14 +123,17 @@
     const Ecm = ecmOf(inp.fck);
     const alphaE = ES / Ecm;
 
-    if (inp.crackAgeDays < 28) {
+    if (inp.crackAgeDays < 28 && inp.mode !== 'watertight') {
       warnings.push('fct,eff is taken as fctm(' + inp.crackAgeDays + ' d) = ' + fctEff.toFixed(2) +
         ' MPa per 7.3.2(2). Several National Annexes impose a floor on fct,eff for early-age ' +
         'restraint — confirm against NA:2010 before relying on this reduction.');
     }
 
-    // --- detailing, §9.6 + NA.9.6.3
-    const AsVMin = 0.002 * Ac / layers;
+    // --- detailing, §9.6 + NA.9.6.2 / NA.9.6.3
+    // NA.9.6.2: "Der det legges særlig vekt på tetthet ... bør armeringen være minst
+    // dobbelt så stor" - the vertical minimum doubles for a tightness-critical wall.
+    const tightness = inp.mode === 'watertight';
+    const AsVMin = (tightness ? 0.004 : 0.002) * Ac / layers;
     const AsVMax = 0.04 * Ac;
     const sVMax = Math.min(3 * t, 400);
     const sHMax = 400;
@@ -149,18 +152,24 @@
 
     // --- crack control, §7.3.2
     const wkInfo = targetWk(inp, t);
-    const kc = inp.kcMode === 'pureTension' ? 1.0 : inp.kcMode === 'house' ? 0.6 : inp.kcCustom;
-    const k = inp.kMode === 'external' ? 1.0 : clamp(lerp(t, 300, 800, 1.0, 0.65), 0.65, 1.0);
+    // NA.9.6.3(1): where tightness governs, the NA fixes the coefficients itself -
+    // eq. (7.1) with fct,eff = fctm (28 d) and both k and kc equal to 1,0. Not negotiable.
+    const kc = tightness ? 1.0
+      : inp.kcMode === 'pureTension' ? 1.0 : inp.kcMode === 'house' ? 0.6 : inp.kcCustom;
+    const k = tightness ? 1.0
+      : inp.kMode === 'external' ? 1.0 : clamp(lerp(t, 300, 800, 1.0, 0.65), 0.65, 1.0);
     const Act = Ac;
-    const AsFloor = kc * k * fctEff * Act / (inp.fyk * layers);
+    // ... and fct,eff is fctm at 28 days, not an early-age value
+    const fctEffUsed = tightness ? fctm : fctEff;
+    const AsFloor = kc * k * fctEffUsed * Act / (inp.fyk * layers);
     const crackActive = inp.crackReq !== 'none' && wkInfo.wk != null;
 
     const bars = [];
     const barsDirect = [];
     if (crackActive) {
       for (const dia of BAR_DIAMETERS) {
-        bars.push(simplifiedBar(dia, inp, { t, Act, kc, k, fctEff, AsFloor, wk: wkInfo.wk, sHMax }));
-        barsDirect.push(directBar(dia, inp, { t, Act, kc, k, fctEff, alphaE, AsFloor, wk: wkInfo.wk, sHMax }));
+        bars.push(simplifiedBar(dia, inp, { t, Act, kc, k, fctEff: fctEffUsed, AsFloor, wk: wkInfo.wk, sHMax }));
+        barsDirect.push(directBar(dia, inp, { t, Act, kc, k, fctEff: fctEffUsed, alphaE, AsFloor, wk: wkInfo.wk, sHMax }));
       }
     }
 
@@ -208,12 +217,13 @@
     pushChecks(checks, {
       inp, t, Ac, layers, AsVMin, AsVMax, AsVProv, AsVTotal, sVMax, sHMax,
       AsHMin, linksNeeded, linksWaived, crackActive, wkInfo, sel, selAlt, hGov, AsFloor, zone,
-      methodEffective
+      methodEffective, tightness
     });
 
-    if (crackActive && wkInfo.wk < 0.2) {
-      warnings.push('wk = ' + wkInfo.wk.toFixed(3) + ' mm is below the range of Table 7.2N. ' +
-        'The simplified route of 7.3.3 cannot answer this — use the direct calculation to 7.3.4.');
+    if (tightness) {
+      warnings.push('NA.9.6.2 and NA.9.6.3: for a wall where tightness governs, the National Annex ' +
+        'doubles the vertical minimum to 0,004·Ac and fixes eq. (7.1) at fct,eff = fctm (28 d) with ' +
+        'k = kc = 1,0. Those three are set for you here and the kc, k and cracking-age inputs are ignored.');
     }
     if (crackActive && layers === 1) {
       warnings.push('A single central layer sits t/2 from the surface, so eq. (7.7N) penalises it ' +
@@ -224,7 +234,7 @@
     return {
       ok: true,
       inputs: inp,
-      material: { fctm, fctEff, Ecm, alphaE, betaCc },
+      material: { fctm, fctEff, fctEffUsed, Ecm, alphaE, betaCc, tightness },
       detailing: {
         Ac, AsVMin, AsVMax, sVMax, sHMax, AsVProv, AsVTotal, kNA, naLeg, quarterLeg,
         AsHMin, AsHMinLeg, links: { needed: linksNeeded, waived: linksWaived }
@@ -290,7 +300,12 @@
   function directBar(dia, inp, ctx) {
     const hMinusD = inp.layers === 2 ? inp.cover + dia / 2 : ctx.t / 2;
     const cEff = inp.layers === 2 ? inp.cover : (ctx.t - dia) / 2;
-    const hcEf = Math.min(2.5 * hMinusD, ctx.t / 2);
+    // NA.7.3.4(3) puts a floor under Ac,eff at hc,eff = (h - d + 1,5ø). Kept inside the t/2
+    // half-section limit of Fig. 7.1(c) so the two faces cannot claim overlapping concrete.
+    const half = ctx.t / inp.layers;
+    const hcEfEc2 = Math.min(2.5 * hMinusD, ctx.t / 2);
+    const hcEfNa = Math.min(hMinusD + 1.5 * dia, half);
+    const hcEf = Math.max(hcEfEc2, hcEfNa);
     const AcEff = 1000 * hcEf;
 
     const wkOf = (As) => {
@@ -374,13 +389,14 @@
       c.inp.vBar.spacing <= c.sVMax ? 'ok' : 'fail',
       'c' + c.inp.vBar.spacing + ' vs max ' + fmt(c.sVMax, 0) + ' mm = min(3t, 400)');
 
-    add('vmin', 'Vertical minimum, 9.6.2(1)',
+    add('vmin', c.tightness ? 'Vertical minimum, NA.9.6.2 (tightness, doubled)' : 'Vertical minimum, NA.9.6.2',
       c.AsVProv >= c.AsVMin ? 'ok' : 'fail',
       'provided ' + fmt(c.AsVProv, 0) + ' vs required ' + fmt(c.AsVMin, 0) + ' mm²/m per layer');
 
     add('vmax', 'Vertical maximum, 9.6.2(1)',
       c.AsVTotal <= c.AsVMax ? 'ok' : 'fail',
-      fmt(c.AsVTotal, 0) + ' vs 0,04·Ac = ' + fmt(c.AsVMax, 0) + ' mm²/m (0,08·Ac at laps)');
+      fmt(c.AsVTotal, 0) + ' vs 0,04·Ac = ' + fmt(c.AsVMax, 0) + ' mm²/m. NA.9.6.2 allows double ' +
+        'at lapped splices only where the laps sit at braced nodes; otherwise the laps must be staggered.');
 
     add('hspacing', 'Horizontal bar spacing, 9.6.3(2)',
       c.hGov.ccMax <= c.sHMax ? 'ok' : 'warn',

--- a/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
+++ b/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
@@ -68,10 +68,13 @@ Plus four ø × cc matrices (`As = 1000/cc · πø²/4`) and two `cc_max` rows.
 - exterior wall: `As,hmin = max(0,25·As,v ; `**`0,30`**`·Ac·fctm/fyk)`
 - interior wall: `As,hmin = max(0,25·As,v ; `**`0,15`**`·Ac·fctm/fyk)`
 
-Confirmed four ways: SCIA's published Norway NA parameter set; SCIA's *Theoretical
-Background — National Annexes to EN 1992*, which cites NS EN 1992-1-1:2004/NA:2010 by name
-and gives both legs verbatim (and confirms 9.6.2(1) is left at the EC2 default, so
-`As,vmin = 0,002·Ac` is unchanged in Norway); the Statens vegvesen /
+**Verified against the standard itself** — NS-EN 1992-1-1:2004+A1:2014+NA:2018, NA.9.6.3(1).
+The clause states the minimum area per face **in doubly reinforced walls** as the greater of
+25 % of the vertical reinforcement *on the same side* and, for exterior walls
+`0,3·Ac·fctm/fyk`, for interior walls `0,15·Ac·fctm/fyk`; and adds that singly reinforced
+walls shall carry the corresponding total area. A second paragraph covers tightness — see
+§2.7 below. Previously corroborated by: SCIA's published Norway NA parameter set; SCIA's
+*Theoretical Background — National Annexes to EN 1992*; the Statens vegvesen /
 Rambøll culvert design example (`As.hmin.vegg = max(0,25·As.vmin ; 0,3·Ac·fctm/fyk)`,
 explicitly *"defineres som yttervegg"*); and a Norwegian retaining-wall report using the
 same expression with `Ac = b·t` and comparing the result against the distribution
@@ -125,8 +128,33 @@ for a fully tensioned section `h − d` is the distance from the bar centroid to
 
 **Norwegian NA.7.3.1(5)** crack width limits: X0 → 0,40 (quasi-permanent);
 XC1–XC4 / XD1–XD2 / XS1–XS2 → `0,30·kc` (quasi-permanent); XD3 / XS3 / XSA → `0,30·kc`
-(frequent); with `kc = cnom/cmin,dur ≤ 1,3`. *(Taken from SCIA's published NA parameter
-set — worth one confirmation against your own copy of NA:2010 before it ships.)*
+(frequent); with `kc = cnom/cmin,dur ≤ 1,3`. **Verified in NA.7.3.1(5), Table NA.7.1N and
+eq. (NA.901) of NA:2018.** Footnote 1 to that table adds that in X0 the crack width does
+not affect durability — the 0,40 limit is for appearance, and may be increased where
+appearance is not a constraint.
+
+### 2.7 What NA:2018 adds that neither the sheet nor the first draft of this plan had
+
+Read from the standard after the module was built; all four are now implemented.
+
+1. **NA.9.6.2** — where tightness governs, the vertical minimum is **at least double**,
+   i.e. `0,004·Ac`. The sheet does not have this.
+2. **NA.9.6.3(1), second paragraph** — where tightness governs, the horizontal minimum comes
+   from eq. (7.1) with **`fct,eff = fctm`** and **`k = kc = 1,0`**. This is the NA blessing the
+   sheet's *vanntett vegg* row exactly, and it also rules out the early-age `fctm(t)`
+   reduction for that case.
+3. **NA.7.3.4(3)** — `k3 = 3,4`, `k4 = 0,425`, and `Ac,eff` shall not be less than that
+   corresponding to `hc,eff = (h − d + 1,5ø)`. A relaxation, binding mainly on single-layer
+   walls.
+4. **NA.9.6.2** — `As,vmax` may be doubled at lapped splices **only where the laps sit at
+   braced nodes**; otherwise laps must be staggered. The blanket "0,08·Ac at laps" reading is
+   too generous.
+
+Also confirmed: the NA amends **only 7.3.2(4)** (σct,p for prestress), so `kc`, `k`,
+`fct,eff` and `Act` in eq. (7.1) are the EC2 values; and footnote 1 to Table NA.7.1N states
+that in X0 the crack width does not affect durability and the 0,40 limit is for appearance,
+which may be increased where appearance is not a constraint — the clause that licenses the
+tool's "no crack control required" option.
 
 ### 2.2 What the sheet gets right
 
@@ -371,9 +399,12 @@ Reuse `ec2concrete/ec2ConcreteUtils.js` for `fctm` / `fctm(t)` — kills trap T1
 
 ## Part 4 — Decisions taken
 
-**Q1 — `k_NA` is an exposure toggle.** 0,30 for `yttervegg`, 0,15 for `innervegg`. The
+**Q1 — `k_NA` is an exposure toggle.** 0,30 for `yttervegg`, 0,15 for `innervegg`.
+**Since verified word for word in NA.9.6.3(1) of NS-EN 1992-1-1:2004+A1:2014+NA:2018.** The
 physical logic is that an exterior wall sees a far larger seasonal range and dries from
-one side, so the restrained strain is roughly double. Implementation: a two-way toggle
+one side, so the restrained strain is roughly double; note also that the interior leg
+reproduces EC2’s own recommended `0,001·Ac` to within a tenth of a per cent across B25 to
+B45, so 0,15 is the baseline and 0,30 is the deliberate uplift. Implementation: a two-way toggle
 with a hint line, plus a numeric override for the awkward cases (a basement wall with
 earth on one side and heated space on the other is normally taken as `yttervegg`).
 
@@ -502,6 +533,7 @@ modes changes which requirement wins, never the shape of the answer.
 
 - BS EN 1992-1-1:2004 §3.1.2, §7.3.2, §7.3.3 (Tables 7.2N / 7.3N, eq. 7.6N / 7.7N), §9.6
 - [EN 1992-3:2006](https://www.phd.eng.br/wp-content/uploads/2015/12/en.1992.3.2006.pdf) §7.3.1 (Table 7.105), §7.3.3 (eq. 7.122), Annex L (Fig. L.1a, **Table L.1**), Annex M (eq. M.3), Annex N (Table N.1)
+- **NS-EN 1992-1-1:2004+A1:2014+NA:2018**, National Annex NA — NA.7.3.1(5) with Table NA.7.1N and eq. (NA.901), NA.7.3.2(4), NA.7.3.4(3), NA.9.6.2, NA.9.6.3(1). Read directly; the authority for every NA value in this module
 - [SCIA — Norwegian National Annex to EN 1992-1-1](https://help.scia.net/25.0/en/national_annexes/en1992/norway.htm) — NA.7.3.1 and NA.9.6.3 parameters
 - [SCIA — Theoretical Background, National Annexes to EN 1992](https://help.scia.net/download/18.0/en/Theory_NA_EN_1992_enu.pdf) — Norway section, citing NS EN 1992-1-1:2004/NA:2010
 - [Statens vegvesen / Rambøll, prefabricated culvert design example](https://www.vegvesen.no/globalassets/fag/teknologi/bruer/prefabrikkerte-kulvertelementer-til-v425/beregningseksempel-2015.pdf) §3.1.4

--- a/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
+++ b/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
@@ -198,9 +198,11 @@ the face of the tool rather than inferred from a column header.
 the governing mechanism for a wall on a base, and `k` only reduces *internal*
 self-equilibrating stresses), but it should be a visible, explained default.
 
-**I4 — the 3 × t zone height is a house rule, not a code rule.** EN 1992-3 Annex L
-Fig. L.1(a) ties the high-restraint zone of a wall on a base to the **wall height and
-L/H ratio**, not the thickness. Keep 3t if that is office practice, but label it as such.
+**I4 — the 3 × t zone height is a house rule, not a code rule.** EN 1992-3 Annex L ties
+the restrained zone of a wall on a base to the **wall height and L/H ratio**, not the
+thickness. 3t turns out to be a decent proxy for stocky walls and unconservative for long
+ones — see §5.1. Keep it as the default, label it as practice, and let the L/H curve
+second-guess it.
 
 **I5 — `fct,eff` frozen at 28 days.** The bottom-of-wall horizontal steel exists to control
 *early-age restraint cracking*, which is exactly the case where EC2 permits `fctm(t)`.
@@ -273,8 +275,10 @@ Two rules follow, and both must be coded rather than left to the reader:
 
 ```
 ┌─ Wall ─────────────────────────────────────────────────────────────────┐
+│ Mode [2 · Wall on base ▾]   □ also restrained top and bottom           │
 │ t [350] mm   Concrete [B35▾]   fyk [500]   Layers [Double▾]            │
 │ cover c [35]  Wall [Exterior▾]  NEd [0] kN/m   Cracking at [28 d▾]     │
+│ kc [1,0] pure tension▾   zone 3t = 1050 mm   L [ ] H [ ] (optional)    │
 └────────────────────────────────────────────────────────────────────────┘
 ┌─ What governs (horizontal, per face) ─┐ ┌─ Crack requirement ──────────┐
 │ ▇▇▇▇▇        9.6.2   As,v     350     │ │ ○ none required     →   672  │
@@ -312,6 +316,8 @@ Per face (or per layer for single-layer walls):
 3. `As,crack = kc·k·fct,eff·Act/(σs·n_faces)` per the ø-indexed loop above
 4. 9.6.4 links trigger and its ø ≤ 16 / cover > 2ø waiver
 5. 9.6.1 scope warnings (L/t < 4, out-of-plane bending → §9.3)
+6. zone height: 3 × t by default, with the EN 1992-3 Table L.1 second opinion when L and H
+   are given (§5.1)
 
 Governing = max of whichever are switched on. The "what governs" bar shows all of them
 side by side, so the cost of the crack requirement reads as a ratio, not a bare number.
@@ -353,30 +359,146 @@ Reuse `ec2concrete/ec2ConcreteUtils.js` for `fctm` / `fctm(t)` — kills trap T1
 - **Single layer**: 200 mm wall, wk = 0,3, full restraint → engine must return
   "not achievable", not a number.
 - **Spacing caps**: t = 100 → `s_v,max = 300`; t = 200 → 400 (not 600).
+- **Table L.1**: L/H = 2 → R_top 0; L/H = 3 → 0,05; L/H = 4 → 0,3; L/H = 12 → 0,5
+  (clamped, not extrapolated); L/H = 3,5 → 0,175 by interpolation.
+- **Zone height**: t = 250, H = 3000, L = 25000 → must report full height and flag that
+  3t (750 mm) is unconservative.
 
 ---
 
-## Part 4 — Open questions
+## Part 4 — Decisions taken
 
-1. **NA wording confirmation.** `NA.9.6.3` k = 0,30 exterior / 0,15 interior is confirmed
-   by three independent sources but not from the standard itself. Same for the
-   `NA.7.3.1(5)` rule `wmax = 0,30·kc`, `kc = cnom/cmin,dur ≤ 1,3`. One look at your copy
-   of NA:2010 settles both.
-2. **Keep the 0,6?** Recommendation: drop it, and replace it with eq. (7.2) driven by the
-   real `NEd` plus an early-age `fct,eff`, which reaches similar numbers with a clause
-   behind each step. If office practice is committed to 0,6, it stays — but as a named,
-   labelled "reduced restraint (house rule)" option, never as a default.
-3. **Zone height.** Keep 3t, or also offer the EN 1992-3 Annex L restraint-factor curve
-   for a wall on a base?
-4. **Scope.** Bottom-zone horizontal restraint steel only, or also full-height vertical
-   and the in-plane shear-wall case?
+**Q1 — `k_NA` is an exposure toggle.** 0,30 for `yttervegg`, 0,15 for `innervegg`. The
+physical logic is that an exterior wall sees a far larger seasonal range and dries from
+one side, so the restrained strain is roughly double. Implementation: a two-way toggle
+with a hint line, plus a numeric override for the awkward cases (a basement wall with
+earth on one side and heated space on the other is normally taken as `yttervegg`).
+
+**Q2 — `kc` is an overwritable default input.** The field ships with a computed default
+and a preset menu, and the user can type over any of it:
+
+| preset | `kc` | basis |
+|---|---|---|
+| pure tension (edge restraint) | 1,0 | 7.3.2(2), the default for a wall on a base |
+| from `NEd` | eq. (7.2) | live from the axial force field; 0,4 at `NEd` = 0 |
+| reduced restraint (house rule) | 0,6 | the sheet's value, labelled as practice |
+| custom | — | free entry |
+
+Whatever is active is printed next to the result with its basis, so a check print always
+says where the number came from.
+
+**Q3 — keep 3 × t as the default; the L/H curve is the second opinion.** See §5.1.
+
+**Q4 — vertical and horizontal are genuinely different problems, and modes are the right
+shape.** See §5.2.
+
+---
+
+## Part 5 — The two answers that needed working out
+
+### 5.1 The restraint curve, and whether 3 × t holds up
+
+**EN 1992-3 Table L.1 — restraint factors for the central zone of a wall on a base:**
+
+| L/H | R at base | R at top |
+|---|---|---|
+| 1 | 0,5 | 0 |
+| 2 | 0,5 | 0 |
+| 3 | 0,5 | 0,05 |
+| 4 | 0,5 | 0,3 |
+| > 8 | 0,5 | 0,5 |
+
+R at the base is **always 0,5** — the base holds the wall completely, and the 0,5 is the
+creep relief on a load that builds up slowly. What changes with L/H is the **top**: a
+stocky wall (L/H ≤ 2) is free at the top and R decays to zero, while a long wall
+(L/H > 8) is held just as hard at the top as at the base. R is taken to vary linearly
+between the two.
+
+**Where R enters is the part that is easy to get wrong.** R does *not* appear in eq. (7.1).
+Eq. (7.1) is an equilibrium statement at the instant of cracking: once the concrete
+reaches `fct,eff` a crack forms and the steel has to catch the released force, and it
+makes no difference what caused the strain. So `As,min` is independent of R.
+
+R appears one step earlier, in **whether that zone cracks at all**. EN 1992-3 Annex M,
+eq. (M.3), for a wall restrained along one edge: `εsm − εcm = Rax·εfree`. A crack forms
+only where `Rax·εfree` exceeds the concrete's tensile strain capacity `εctu`, i.e. where
+
+```
+R(z) > R_crit = εctu / εfree
+```
+
+For a typical Norwegian basement wall — early-thermal rise ~25–30 °C, `αc` = 10·10⁻⁶/°C,
+plus autogenous shrinkage — `εfree` ≈ 300–350 με and `εctu` ≈ 75–110 με, so
+`R_crit` ≈ 0,25–0,35. Reading that back off the linear R(z) gives the height over which
+the extra horizontal steel is actually needed. For H = 3,0 m:
+
+| L/H | R_crit = 0,25 | R_crit = 0,31 | R_crit = 0,35 |
+|---|---|---|---|
+| 1–2 | 1500 mm | 1140 mm | 900 mm |
+| 3 | 1667 mm | 1267 mm | 1000 mm |
+| 4 | full height | 2850 mm | 2250 mm |
+| ≥ 6 | full height | full height | full height |
+
+**So 3 × t is a good rule where it came from and a trap where it did not.** For a 350 mm
+wall, 3t = 1050 mm, and for L/H ≤ 3 the curve lands at 900–1670 mm — 3t sits right in the
+band. That is almost certainly why the rule exists: the ordinary Norwegian basement wall
+is stocky, and for stocky walls it happens to be right.
+
+But the rule keys off **thickness**, and the physics keys off **length over height**. At
+L/H ≥ 4 the restrained zone runs the full height of the wall, and long retaining and
+basement walls are exactly where that bites. A 250 mm × 3 m × 25 m wall gets 750 mm of
+extra steel under the 3t rule and needs it over all 3000 mm.
+
+Implementation, and deliberately modest:
+
+- default the zone height to **3 × t**, labelled *"practice (NO) — not an EC2 rule"*
+- take `L` and `H` as two optional fields. When both are filled, show a second line:
+  *"EN 1992-3 Table L.1: L/H = 8,0 → R = 0,50 at base and top → extra reinforcement over
+  the full height, 3000 mm, not 750 mm"*
+- expose `εfree` and `εctu` as advanced fields with the Norwegian defaults above, because
+  `R_crit` is the whole ballgame and pretending otherwise would be dishonest
+- do **not** grow this into an early-thermal crack calculator. It reports a height and a
+  warning; it does not compute `T1`.
+
+### 5.2 Vertical vs horizontal, and the mode list
+
+They are different problems, and the sheet is right to treat only the horizontal bars as
+crack-driven:
+
+- **Horizontal bars** carry the edge restraint. The wall wants to shorten along its length
+  and the base will not let it, so the tension is horizontal and the cracks are vertical.
+  7.3.2 governs here, typically by a factor of 3 over the detailing minimum.
+- **Vertical bars** are almost never restraint-critical. The wall is free to shorten
+  vertically — only the bottom is held, over a short distance — so 9.6.2's `0,002·Ac` and
+  whatever out-of-plane bending the wall carries are what govern. The exception is a wall
+  cast **between** two slabs, where the vertical direction is restrained top and bottom
+  too, and that is a separate situation rather than a different formula.
+
+So modes are structural situations, and each one switches on a set of requirements:
+
+| mode | vertical | horizontal | notes |
+|---|---|---|---|
+| **1. Ordinary wall** (above ground) | 9.6.2 | NA.9.6.3 | detailing only; the fast path |
+| **2. Wall on base** (basement, retaining) | 9.6.2 | NA.9.6.3 + **7.3.2 edge restraint** in the bottom zone | the sheet's *vanlig vegg* |
+| **3. Watertight** (lift pit, tank) | 9.6.2 | NA.9.6.3 + **7.3.2** with EN 1992-3 `wk1` from `hD/h` and the (7.122) bar rule | the sheet's *vanntett vegg* |
+| **4. Restrained top and bottom** (cast between slabs) | 9.6.2 + **7.3.2** | as mode 2 | a checkbox on modes 1–3, not its own mode |
+
+Modes 1–3 plus the mode 4 checkbox are v1. Mode 2 is the default, because it is what
+people open the tool for.
+
+**Out of scope, stated explicitly in the README**: in-plane shear walls and coupling
+beams. That is a strength problem driven by analysis forces, not a minimum-reinforcement
+problem, and folding it in would blur what this tool is for.
+
+Every mode still ends at the same place — the ø-indexed table of §3.1 — so switching
+modes changes which requirement wins, never the shape of the answer.
 
 ---
 
 ## Sources
 
 - BS EN 1992-1-1:2004 §3.1.2, §7.3.2, §7.3.3 (Tables 7.2N / 7.3N, eq. 7.6N / 7.7N), §9.6
-- [EN 1992-3:2006](https://www.phd.eng.br/wp-content/uploads/2015/12/en.1992.3.2006.pdf) §7.3.1 (Table 7.105), §7.3.3 (eq. 7.122), Annex L, Annex M, Annex N
+- [EN 1992-3:2006](https://www.phd.eng.br/wp-content/uploads/2015/12/en.1992.3.2006.pdf) §7.3.1 (Table 7.105), §7.3.3 (eq. 7.122), Annex L (Fig. L.1a, **Table L.1**), Annex M (eq. M.3), Annex N (Table N.1)
 - [SCIA — Norwegian National Annex to EN 1992-1-1](https://help.scia.net/25.0/en/national_annexes/en1992/norway.htm) — NA.7.3.1 and NA.9.6.3 parameters
 - [Statens vegvesen / Rambøll, prefabricated culvert design example](https://www.vegvesen.no/globalassets/fag/teknologi/bruer/prefabrikkerte-kulvertelementer-til-v425/beregningseksempel-2015.pdf) §3.1.4
 - [Norwegian retaining-wall worked example (jet-as.no)](https://jet-as.no/onewebmedia/Regneeksempel%20for%20st%C3%B8ttemur%20revidert.pdf) §9, §10

--- a/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
+++ b/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
@@ -1,0 +1,382 @@
+# Minimum reinforcement for walls — audit of `Minimumsarmering.xlsm!Vegg` and module plan
+
+**Status**: planning
+**Date**: 2026-08-21
+**Proposed module folder**: `concrete_wall_minimum_reinforcement/`
+**Source reviewed**: `local_docs/Minimumsarmering.xlsm`, sheet `Vegg` (git-ignored, stays local)
+
+---
+
+## Part 0 — TL;DR
+
+The `Vegg` sheet gets the two hard things right: the Norwegian NA form of `As,h,min` and
+the shape of EC2 (7.1). It has **one real formula bug**, **one silent-zero trap**, and it
+hardcodes the single number the whole design decision actually hinges on — the steel
+stress `σs`. Because `σs` is frozen at 240 MPa and `kc` at an untraceable 0,6, the sheet
+cannot show the user the trade-off they care about: *how much steel does each crack
+requirement actually cost me?*
+
+The new module's job is to make that trade-off the main screen. One row of inputs, one
+"what governs" bar, one scenario list, and one **ø-indexed table where each bar diameter
+carries its own permitted `σs`, and therefore its own required area and spacing**. That
+last idea is the reason this module is worth building and is not a port of the sheet.
+
+---
+
+## Part 1 — What the sheet does
+
+Reconstructed from the cell formulas (t = 350 mm, B35, fyk = 500, exterior wall):
+
+| Cell | Label | Formula | Value |
+|---|---|---|---|
+| `C5` | fctm | `SUMIF(G2:G4, C4, H2:H4)` | 3,2 |
+| `K4` | As,v provided | `1000/cc · πø²/4` (ø12 c250) | 452 mm²/m |
+| `C7` | **As,h,min** (NA.9.6.3) | `MAX(k·1000·t·fctm/fyk ; 0,25·K4)`, k = 0,3 | 672 mm²/m per face |
+| `C8` | **As,v,min** (9.6.2) | `0,002·1000·t/2` | 350 mm²/m per face |
+| `J9`, `J10` | single-layer wall | `2·C8`, `2·C7` | 700 / 1344 mm²/m |
+| `C15` | crack, ordinary wall | `0,5·1·`**`0,6`**`·fctm·t·1000/240` | 1400 mm²/m per face |
+| `C16` | additional | `C15 − C7` | 728 mm²/m |
+| `C22` | crack, watertight wall | `0,5·1·`**`1,0`**`·fctm·t·1000/240` | 2333 mm²/m per face |
+| `C23` | additional | `C22 − `**`C16`** | 1605 mm²/m |
+| `C13`, `C20` | zone height | `3·t` | 1050 mm |
+
+Plus four ø × cc matrices (`As = 1000/cc · πø²/4`) and two `cc_max` rows.
+
+---
+
+## Part 2 — Verification against EC2 + NA
+
+### 2.1 Clause text used (verified against the standards, not from memory)
+
+**EN 1992-1-1 §9.6 — walls**
+
+- 9.6.1(1): §9.6 applies to walls with **length/thickness ≥ 4**. Walls predominantly in
+  out-of-plane bending follow the **slab** rules (§9.3) instead.
+- 9.6.2(1): `As,vmin ≤ As,v ≤ As,vmax`; recommended `As,vmin = 0,002·Ac`,
+  `As,vmax = 0,04·Ac` outside laps (may be doubled at laps).
+- 9.6.2(2): where `As,vmin` controls, **half at each face**.
+- 9.6.2(3): vertical bar spacing ≤ **lesser of 3t and 400 mm**.
+- 9.6.3(1): horizontal reinforcement **at each surface**, not less than `As,hmin`
+  (recommended: greater of 25 % of the vertical reinforcement and `0,001·Ac`).
+- 9.6.3(2): horizontal bar spacing ≤ **400 mm**.
+- 9.6.4(1): links per §9.5.3 where total vertical steel in both faces > `0,02·Ac`.
+- 9.6.4(2): ≥ 4 links/m² where the main reinforcement is nearest the faces — **waived**
+  for mesh and bars ø ≤ 16 mm with cover > 2ø.
+
+**Norwegian NA.9.6.3** replaces the recommended `As,hmin`:
+
+- exterior wall: `As,hmin = max(0,25·As,v ; `**`0,30`**`·Ac·fctm/fyk)`
+- interior wall: `As,hmin = max(0,25·As,v ; `**`0,15`**`·Ac·fctm/fyk)`
+
+Confirmed three ways: SCIA's published Norway NA parameter set; the Statens vegvesen /
+Rambøll culvert design example (`As.hmin.vegg = max(0,25·As.vmin ; 0,3·Ac·fctm/fyk)`,
+explicitly *"defineres som yttervegg"*); and a Norwegian retaining-wall report using the
+same expression with `Ac = b·t` and comparing the result against the distribution
+reinforcement **at each face separately**.
+
+**EN 1992-1-1 §7.3.2(2), eq. (7.1)**: `As,min·σs = kc·k·fct,eff·Act`
+
+- `kc = 1,0` for **pure tension**; for bending / bending + axial, eq. (7.2)
+  `kc = 0,4·[1 − σc/(k1·(h/h*)·fct,eff)] ≤ 1`, with `k1 = 1,5` for compressive `NEd`.
+  Pure bending with `NEd = 0` gives `kc = 0,4`.
+- `k = 1,0` for h ≤ 300 mm, `0,65` for h ≥ 800 mm, interpolate. It accounts for
+  **non-uniform self-equilibrating (internal) stresses** only.
+- `fct,eff = fctm`, **or lower `fctm(t)` if cracking is expected earlier than 28 days**;
+  `fctm(t) = βcc(t)^α · fctm`, `α = 1` for t < 28 d (eq. 3.4 / 3.2).
+- `σs` = max stress permitted in the steel immediately after cracking; may be taken as
+  `fyk`, **but a lower value may be needed to meet the crack width limit via 7.3.3(2)**.
+
+**EN 1992-1-1 §7.3.3(2)** — the part the sheet is missing:
+
+> for cracking caused **dominantly by restraint**, the bar sizes given in **Table 7.2N**
+> are not exceeded where the steel stress is the value obtained immediately after
+> cracking (i.e. σs in Expression (7.1)).
+
+Note that **Table 7.3N (spacing) does not apply to restraint-dominated cracking** — only 7.2N.
+
+Table 7.2N, `φ*s` [mm]:
+
+| σs [MPa] | wk 0,4 | wk 0,3 | wk 0,2 |
+|---|---|---|---|
+| 160 | 40 | 32 | 25 |
+| 200 | 32 | 25 | 16 |
+| 240 | 20 | 16 | 12 |
+| 280 | 16 | 12 | 8 |
+| 320 | 12 | 10 | 6 |
+| 360 | 10 | 8 | 5 |
+| 400 | 8 | 6 | 4 |
+| 450 | 6 | 5 | — |
+
+adjusted by (7.7N) for uniform axial tension: `φs = φ*s·(fct,eff/2,9)·hcr/(8(h−d))`, where
+for a fully tensioned section `h − d` is the distance from the bar centroid to the
+**nearest** face. (EN 1992-3 eq. 7.122 replaces the 8 with 10 for liquid-retaining.)
+
+**EN 1992-3** — for the watertight case
+
+- Table 7.105 tightness classes 0–3; Class 1 limits through-cracks to `wk1`, interpolated
+  on `hD/h` (hydrostatic head / wall thickness): `hD/h ≤ 5 → 0,2 mm`, `≥ 35 → 0,05 mm`.
+- Annex L Fig. L.1(a) gives restraint factors for a **wall cast on a base**.
+- **Table N.1(b)**: if the design provides close movement joints (greater of 5 m or
+  1,5 × wall height), reinforcement need only satisfy **§9.6.2–9.6.4** — i.e. the 7.3.2
+  crack minimum drops out entirely. A legitimate, code-sanctioned escape hatch.
+
+**Norwegian NA.7.3.1(5)** crack width limits: X0 → 0,40 (quasi-permanent);
+XC1–XC4 / XD1–XD2 / XS1–XS2 → `0,30·kc` (quasi-permanent); XD3 / XS3 / XSA → `0,30·kc`
+(frequent); with `kc = cnom/cmin,dur ≤ 1,3`. *(Taken from SCIA's published NA parameter
+set — worth one confirmation against your own copy of NA:2010 before it ships.)*
+
+### 2.2 What the sheet gets right
+
+- `fctm` for B30 / B35 / B45 = 2,9 / 3,2 / 3,8 — matches EC2 Table 3.1.
+- `As,v,min = 0,002·Ac`, half at each face — 9.6.2(1) + (2). ✔
+- `As,h,min = max(0,25·As,v ; 0,30·Ac·fctm/fyk)` with the full `Ac` — matches NA.9.6.3 and
+  all three independent sources. Using the **provided** vertical steel for the 25 % leg
+  (rather than `As,vmin`) is the stricter and more correct reading of "the vertical
+  reinforcement". ✔
+- The structure of (7.1) with `Act = b·t` and half the steel per face. ✔
+- `kc = 1,0` for the watertight case. ✔
+- All matrix arithmetic (`As = 1000/cc · πø²/4`). ✔
+
+### 2.3 Errors
+
+**E1 — `C23` subtracts the wrong cell.** `C23 = C22 − C16` takes the *additional* steel
+from the ordinary-wall case off the watertight total. It should be `C22 − C7` (total minus
+the code minimum). At t = 350 that is 1605 vs 1661 mm²/m; the gap tracks `C16`, so it
+grows with wall thickness and concrete class. Real bug.
+
+**E2 — `Betongkvaliteter` sheet has B45 → fctm 3,5.** EC2 Table 3.1 gives **3,8** for
+C45/55 (3,5 is C40/50). The `Vegg` sheet's own lookup has 3,8 and is unaffected, but
+`GPG!B9` reads this table with fck = 45, so every GPG minimum comes out ~8 % low.
+
+**E3 — `NS3473_overflatearmering` lookup is mis-keyed.** The label column runs
+B20/B25/B30/B35/B40/B45/B55 while the `fcck` column runs 20/25/30/35/**45**/**55**/**65**.
+Selecting "B40" returns ftk 3,35 and "B45" returns 3,7. Either an off-by-one or an
+undocumented cube-grade mapping — worth checking against NS 3473 table 5.
+
+### 2.4 Silent-failure traps
+
+**T1 — `SUMIF` returns zero for unlisted concrete.** `C5` only knows B30 / B35 / B45. Type
+B25 or B40 and `fctm` becomes **0**, so `As,h,min` and every crack requirement become 0
+with no warning at all. Replace with the closed form: `fctm = 0,30·fck^(2/3)` for
+fck ≤ 50, `2,12·ln(1 + (fck+8)/10)` above. (The repo already has this in
+`ec2concrete/ec2ConcreteUtils.js` — reuse it.)
+
+**T2 — two disconnected definitions of the vertical steel.** `K4` (from `K2`/`K3`) feeds
+the 25 % leg, but `C8` is the vertical minimum and the ø × cc matrices are a third,
+unlinked place to pick bars. Change one and the others go stale silently.
+
+### 2.5 Code requirements the sheet never checks
+
+| # | Missing | Clause |
+|---|---|---|
+| M1 | vertical bar spacing ≤ min(3t, 400 mm) | 9.6.2(3) |
+| M2 | horizontal bar spacing ≤ 400 mm | 9.6.3(2) |
+| M3 | `As,v,max = 0,04·Ac` (0,08 at laps) | 9.6.2(1) |
+| M4 | links if vertical steel > 0,02·Ac; ≥ 4 links/m² rule and its ø ≤ 16 waiver | 9.6.4 |
+| M5 | scope: length/thickness ≥ 4; out-of-plane bending → slab rules | 9.6.1(1) |
+| M6 | **bar diameter compatible with σs and wk** (Table 7.2N + eq. 7.7N) | 7.3.3(2) |
+
+M6 is the serious one. The sheet reports 1400 mm²/m and stops. You can satisfy
+1400 mm²/m with ø25 c350 and be nowhere near wk = 0,3 — the area is met and the crack
+width is not.
+
+### 2.6 Interpretation choices that are buried and should be explicit
+
+**I1 — `kc = 0,6` for "vanlig vegg" is not an EC2 number.** EC2 offers 1,0 (pure tension)
+or eq. (7.2) (0,4 at pure bending, less with compression). 0,6 sits between them with no
+clause behind it, and it is doing all the work in that row — it is the entire difference
+between 1400 and 2333 mm²/m. The legitimate levers that reach similar numbers are:
+eq. (7.2) with the real `NEd`, `fct,eff = fctm(t)` for early-age cracking, the `wk` choice
+itself, and movement joints per EN 1992-3 Table N.1(b).
+
+**I2 — `As,h,min` per face vs total.** The sheet applies the NA formula with the full `Ac`
+and calls the result *per face*, which doubles the total. That matches SCIA and both
+Norwegian design reports, so the reading is defensible — but it deserves to be printed on
+the face of the tool rather than inferred from a column header.
+
+**I3 — `k = 1,0` hardcoded.** Correct and conservative here (external / edge restraint is
+the governing mechanism for a wall on a base, and `k` only reduces *internal*
+self-equilibrating stresses), but it should be a visible, explained default.
+
+**I4 — the 3 × t zone height is a house rule, not a code rule.** EN 1992-3 Annex L
+Fig. L.1(a) ties the high-restraint zone of a wall on a base to the **wall height and
+L/H ratio**, not the thickness. Keep 3t if that is office practice, but label it as such.
+
+**I5 — `fct,eff` frozen at 28 days.** The bottom-of-wall horizontal steel exists to control
+*early-age restraint cracking*, which is exactly the case where EC2 permits `fctm(t)`.
+This is the single largest legitimate reduction on the table and the sheet does not
+offer it.
+
+---
+
+## Part 3 — The module
+
+### 3.1 The idea that makes it different
+
+For restraint cracking, 7.3.3(2) ties the permitted `σs` to the **bar diameter** through
+Table 7.2N. And `σs` sits in the denominator of (7.1). So the required area is a function
+of the bar you choose:
+
+```
+ø  →  φ*s required = ø / [(fct,eff/2,9) · hcr/(8(h−d))]
+   →  σs = invert Table 7.2N at the target wk        (interpolated)
+   →  As,req = kc·k·fct,eff·Act / σs
+   →  cc,max = 1000·(πø²/4) / As,req
+```
+
+Small bars buy a high permitted stress and therefore **less** steel; big bars are penalised
+twice (lower `σs`, and a larger area to cover with fewer bars). That is counter-intuitive,
+it is what the code actually says, and no spreadsheet in the office shows it. Worked for
+t = 350, B35, c = 35, wk = 0,3, kc = k = 1,0:
+
+| ø | 8 | 10 | 12 | 16 | 20 | 25 |
+|---|---|---|---|---|---|---|
+| `φ*s` required | 6,5 | 8,3 | 10,2 | 14,3 | 18,6 | 24,6 |
+| σs [MPa] | 391 | 354 | 316 | 257 | 228 | 202 |
+| As,req [mm²/m per face] | 1433 | 1581 | 1771 | 2175 | 2453 | 2775 |
+| cc,max [mm] | 35 | 50 | 64 | 92 | 128 | 177 |
+
+Same wall, same restraint, only the crack requirement changed — the whole point of the
+tool in one comparison (all at ø16):
+
+| requirement | σs [MPa] | As,req [mm²/m per face] | cc,max for ø16 |
+|---|---|---|---|
+| detailing only (NA.9.6.3) | — | 672 | c300 |
+| wk = 0,4 | 297 | 1882 | c107 |
+| wk = 0,3 | 257 | 2175 | c92 |
+| wk = 0,2 | 217 | 2575 | c78 |
+| wk = 0,3, cracking at 3 d (`fct,eff` = 0,6·fctm) | 206 | 1635 | c123 |
+
+The last row is the honest reduction the sheet's `kc = 0,6` was reaching for: 1635 vs
+1400 mm²/m, but every step of it traceable to a clause.
+
+*(Cross-check: force `σs = 240` and `kc = 1,0` and the formula returns 2333 mm²/m —
+exactly the sheet's `C22`; and `0,3·Ac·fctm/fyk` returns 672 = `C7`. The model reproduces
+the sheet everywhere the sheet is right.)*
+
+The same machinery answers the single-vs-double-layer question honestly. For a single
+central layer, `h − d = t/2`, so the (7.7N) factor collapses to roughly `t/(4t) = 0,25`:
+a 200 mm single-layer wall under full restraint needs `φ*s` ≈ 29 for ø8 and ≈ 58 for
+ø16, which is off the top of Table 7.2N entirely. σs pins at the 160 MPa floor and
+As,req reaches 4000 mm²/m in one layer.
+
+Two rules follow, and both must be coded rather than left to the reader:
+
+- **Never silently clamp.** If the required `φ*s` falls outside Table 7.2N's range the
+  answer is *"outside the table — direct calculation to 7.3.4 required"*, not a number
+  produced by pinning σs at 160. Clamping is how a tool tells a comfortable lie.
+- **Say it in words.** For a singly reinforced wall under edge restraint the module
+  should state that crack control is not achievable in one layer and that a second layer
+  (or movement joints) is the fix — instead of printing an unbuildable spacing.
+
+### 3.2 Screen (single view, no scrolling on a laptop)
+
+```
+┌─ Wall ─────────────────────────────────────────────────────────────────┐
+│ t [350] mm   Concrete [B35▾]   fyk [500]   Layers [Double▾]            │
+│ cover c [35]  Wall [Exterior▾]  NEd [0] kN/m   Cracking at [28 d▾]     │
+└────────────────────────────────────────────────────────────────────────┘
+┌─ What governs (horizontal, per face) ─┐ ┌─ Crack requirement ──────────┐
+│ ▇▇▇▇▇        9.6.2   As,v     350     │ │ ○ none required     →   672  │
+│ ▇▇▇▇▇▇▇▇▇▇   NA.9.6.3 As,h    672     │ │ ○ wk 0,4            →  1882  │
+│ ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 7.3.2      2175     │ │ ● wk 0,3·kc (XC/XD) →  2175  │
+│ → 7.3.2 governs, ×3,2 over detailing  │ │ ○ wk 0,2            →  2575  │
+└───────────────────────────────────────┘ │ ○ EN1992-3 Class 1  →  2960  │
+                                          │ ○ movement joints   →   672  │
+                                          └──────────────────────────────┘
+┌─ Pick your bar (horizontal, bottom zone, per face) ────────────────────┐
+│  ø        8     10    12    16    20    25                             │
+│  σs      391   354   316   257   228   202   MPa   Tab 7.2N + (7.7N)   │
+│  As,req 1433  1581  1771  2175  2453  2775   mm²/m                     │
+│  cc,max  c35   c50   c64   c92  c128  c177                             │
+│  verdict  ✗     ✗     ⚠     ✓     ✓     ✓    (✗ = cc below buildable)  │
+└────────────────────────────────────────────────────────────────────────┘
+┌─ ø × cc matrix ─── [horizontal ▾ | vertical] ──────────────────────────┐
+│         ø8    ø10   ø12   ø16   ø20   ø25       green ≥ req            │
+│  c100   503   785  1131  2011  3142  4909       amber within 5 %       │
+│  c150   335   524   754  1340  2094  3272       red   < req            │
+│  c200   251   393   565  1005  1571  2454       grey  spacing > smax   │
+│  ...                                            hatch ø fails Tab 7.2N │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+Everything above recomputes live. No Calculate button.
+
+### 3.3 Requirement set the engine evaluates
+
+Per face (or per layer for single-layer walls):
+
+1. `As,v,min = 0,002·Ac / n_layers`, `As,v,max = 0,04·Ac`, `s_v,max = min(3t, 400)`
+2. `As,h,min = max(0,25·As,v,provided ; k_NA·Ac·fctm/fyk)`, k_NA = 0,30 ext / 0,15 int,
+   `s_h,max = 400`
+3. `As,crack = kc·k·fct,eff·Act/(σs·n_faces)` per the ø-indexed loop above
+4. 9.6.4 links trigger and its ø ≤ 16 / cover > 2ø waiver
+5. 9.6.1 scope warnings (L/t < 4, out-of-plane bending → §9.3)
+
+Governing = max of whichever are switched on. The "what governs" bar shows all of them
+side by side, so the cost of the crack requirement reads as a ratio, not a bare number.
+
+### 3.4 Files
+
+```
+concrete_wall_minimum_reinforcement/
+  index.html                 # UI, GA tag immediately after <head>, shared assets/css
+  wall_min_reinf_api.js      # pure calc layer, no DOM (per plan_IO-structure_for_modules)
+  script.js                  # UI wiring + MODULE_CONFIG / ModuleAPI workflow layer
+  print.css
+  README.md
+```
+
+Reuse `ec2concrete/ec2ConcreteUtils.js` for `fctm` / `fctm(t)` — kills trap T1 outright.
+
+### 3.5 Deployment (per DEPLOYMENT.md — both edits are required or the page 404s)
+
+- add `'concrete_wall_minimum_reinforcement/**'` to the `paths:` trigger in
+  `.github/workflows/deploy-all-modules.yml`
+- add the folder to the **copy-loop allowlist** (`for dir in … ; do`) in the same file
+- do **not** touch `module-registry/module-registry.json` — it is regenerated from
+  `index.html` on every deploy
+- landing-page card under Concrete
+
+### 3.6 Test plan
+
+- **Sheet parity**: force `σs = 240`, `kc = 1,0`, `k = 1,0`, 28-day `fct,eff` → must return
+  `C7 = 672`, `C8 = 350`, `C22 = 2333` for t = 350 / B35 / exterior.
+- **Rambøll culvert**: t = 240, B45, exterior → `As,hmin = 547 mm²/m`,
+  `As,vmin = 480 mm²/m` total, `s_v,max = 400`, `As,vmax = 9600`.
+- **Norwegian retaining wall**: t = 400, fctm 3,2, exterior → `0,3·Ac·fctm/fyk = 768`
+  and `As,vmin = 400 mm²/m` per face.
+- **Table 7.2N inversion**: exact table points round-trip; interpolation monotonic; clamp
+  at σs ∈ [160, 450] and flag out-of-range rather than extrapolating.
+- **fctm**: every class C12/15 … C90/105 against Table 3.1; and specifically B25 and B40,
+  which the sheet silently zeroes.
+- **Single layer**: 200 mm wall, wk = 0,3, full restraint → engine must return
+  "not achievable", not a number.
+- **Spacing caps**: t = 100 → `s_v,max = 300`; t = 200 → 400 (not 600).
+
+---
+
+## Part 4 — Open questions
+
+1. **NA wording confirmation.** `NA.9.6.3` k = 0,30 exterior / 0,15 interior is confirmed
+   by three independent sources but not from the standard itself. Same for the
+   `NA.7.3.1(5)` rule `wmax = 0,30·kc`, `kc = cnom/cmin,dur ≤ 1,3`. One look at your copy
+   of NA:2010 settles both.
+2. **Keep the 0,6?** Recommendation: drop it, and replace it with eq. (7.2) driven by the
+   real `NEd` plus an early-age `fct,eff`, which reaches similar numbers with a clause
+   behind each step. If office practice is committed to 0,6, it stays — but as a named,
+   labelled "reduced restraint (house rule)" option, never as a default.
+3. **Zone height.** Keep 3t, or also offer the EN 1992-3 Annex L restraint-factor curve
+   for a wall on a base?
+4. **Scope.** Bottom-zone horizontal restraint steel only, or also full-height vertical
+   and the in-plane shear-wall case?
+
+---
+
+## Sources
+
+- BS EN 1992-1-1:2004 §3.1.2, §7.3.2, §7.3.3 (Tables 7.2N / 7.3N, eq. 7.6N / 7.7N), §9.6
+- [EN 1992-3:2006](https://www.phd.eng.br/wp-content/uploads/2015/12/en.1992.3.2006.pdf) §7.3.1 (Table 7.105), §7.3.3 (eq. 7.122), Annex L, Annex M, Annex N
+- [SCIA — Norwegian National Annex to EN 1992-1-1](https://help.scia.net/25.0/en/national_annexes/en1992/norway.htm) — NA.7.3.1 and NA.9.6.3 parameters
+- [Statens vegvesen / Rambøll, prefabricated culvert design example](https://www.vegvesen.no/globalassets/fag/teknologi/bruer/prefabrikkerte-kulvertelementer-til-v425/beregningseksempel-2015.pdf) §3.1.4
+- [Norwegian retaining-wall worked example (jet-as.no)](https://jet-as.no/onewebmedia/Regneeksempel%20for%20st%C3%B8ttemur%20revidert.pdf) §9, §10

--- a/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
+++ b/global-devspecs/concrete_wall_minimum_reinforcement-plan.md
@@ -68,7 +68,10 @@ Plus four ø × cc matrices (`As = 1000/cc · πø²/4`) and two `cc_max` rows.
 - exterior wall: `As,hmin = max(0,25·As,v ; `**`0,30`**`·Ac·fctm/fyk)`
 - interior wall: `As,hmin = max(0,25·As,v ; `**`0,15`**`·Ac·fctm/fyk)`
 
-Confirmed three ways: SCIA's published Norway NA parameter set; the Statens vegvesen /
+Confirmed four ways: SCIA's published Norway NA parameter set; SCIA's *Theoretical
+Background — National Annexes to EN 1992*, which cites NS EN 1992-1-1:2004/NA:2010 by name
+and gives both legs verbatim (and confirms 9.6.2(1) is left at the EC2 default, so
+`As,vmin = 0,002·Ac` is unchanged in Norway); the Statens vegvesen /
 Rambøll culvert design example (`As.hmin.vegg = max(0,25·As.vmin ; 0,3·Ac·fctm/fyk)`,
 explicitly *"defineres som yttervegg"*); and a Norwegian retaining-wall report using the
 same expression with `Ac = b·t` and comparing the result against the distribution
@@ -500,5 +503,6 @@ modes changes which requirement wins, never the shape of the answer.
 - BS EN 1992-1-1:2004 §3.1.2, §7.3.2, §7.3.3 (Tables 7.2N / 7.3N, eq. 7.6N / 7.7N), §9.6
 - [EN 1992-3:2006](https://www.phd.eng.br/wp-content/uploads/2015/12/en.1992.3.2006.pdf) §7.3.1 (Table 7.105), §7.3.3 (eq. 7.122), Annex L (Fig. L.1a, **Table L.1**), Annex M (eq. M.3), Annex N (Table N.1)
 - [SCIA — Norwegian National Annex to EN 1992-1-1](https://help.scia.net/25.0/en/national_annexes/en1992/norway.htm) — NA.7.3.1 and NA.9.6.3 parameters
+- [SCIA — Theoretical Background, National Annexes to EN 1992](https://help.scia.net/download/18.0/en/Theory_NA_EN_1992_enu.pdf) — Norway section, citing NS EN 1992-1-1:2004/NA:2010
 - [Statens vegvesen / Rambøll, prefabricated culvert design example](https://www.vegvesen.no/globalassets/fag/teknologi/bruer/prefabrikkerte-kulvertelementer-til-v425/beregningseksempel-2015.pdf) §3.1.4
 - [Norwegian retaining-wall worked example (jet-as.no)](https://jet-as.no/onewebmedia/Regneeksempel%20for%20st%C3%B8ttemur%20revidert.pdf) §9, §10

--- a/index.html
+++ b/index.html
@@ -851,8 +851,8 @@
         </div>
       </div>
 
-      <!-- Row 3: Concrete Minimum Reinforcement -->
-      <div class="grid md:grid-cols-1 gap-8 mb-8">
+      <!-- Row 3: Minimum Reinforcement calculators -->
+      <div class="grid md:grid-cols-2 gap-8 mb-8">
         <!-- Concrete Minimum Reinforcement Calculator -->
         <div class="tool-card rounded-xl p-8">
           <div class="flex items-center mb-4">
@@ -877,6 +877,41 @@
 
           <a href="./concrete_minimum_reinforcement/index.html"
              class="inline-flex items-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-lg transition group">
+            Launch Calculator
+            <svg class="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
+        </div>
+
+        <!-- Wall Minimum Reinforcement Calculator -->
+        <div class="tool-card rounded-xl p-8">
+          <div class="flex items-center mb-4">
+            <div class="w-12 h-12 bg-sky-500 rounded-lg flex items-center justify-center mr-4">
+              <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4h16v16H4zM4 10h16M4 16h16M10 4v6M14 10v6M8 16v4M16 16v4" />
+              </svg>
+            </div>
+            <h3 class="text-2xl font-bold text-white">Wall Minimum Reinforcement</h3>
+          </div>
+
+          <p class="text-gray-300 mb-6 leading-relaxed">
+            Minimum reinforcement for concrete walls to EC2 and the Norwegian National Annex &mdash; 9.6.2 vertical,
+            NA.9.6.3 horizontal, and restraint crack control to 7.3.2 by both the Table 7.2N route and direct
+            calculation to 7.3.4, with EN 1992-3 for watertight walls. Because 7.3.3(2) ties the permitted steel
+            stress to the bar diameter, every bar size carries its own required area and spacing &mdash; so you can
+            see in one glance what each crack requirement actually costs, instead of over-reinforcing by default.
+          </p>
+
+          <div class="flex flex-wrap gap-2 mb-6">
+            <span class="px-3 py-1 bg-sky-500/20 text-sky-300 rounded-full text-sm">NA.9.6.3</span>
+            <span class="px-3 py-1 bg-cyan-500/20 text-cyan-300 rounded-full text-sm">Crack Control</span>
+            <span class="px-3 py-1 bg-violet-500/20 text-violet-300 rounded-full text-sm">Edge Restraint</span>
+            <span class="px-3 py-1 bg-emerald-500/20 text-emerald-300 rounded-full text-sm">Watertight Walls</span>
+          </div>
+
+          <a href="./concrete_wall_minimum_reinforcement/index.html"
+             class="inline-flex items-center px-6 py-3 bg-sky-600 hover:bg-sky-700 text-white font-semibold rounded-lg transition group">
             Launch Calculator
             <svg class="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />

--- a/index.html
+++ b/index.html
@@ -903,6 +903,13 @@
             see in one glance what each crack requirement actually costs, instead of over-reinforcing by default.
           </p>
 
+          <div class="mb-4 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+            <p class="text-yellow-300 text-sm font-medium">
+              &#9888;&#65039; Under Development: new tool, may contain errors. Written against the
+              <b>Norwegian National Annex</b> (NS-EN 1992-1-1+NA:2018) &mdash; verify results independently.
+            </p>
+          </div>
+
           <div class="flex flex-wrap gap-2 mb-6">
             <span class="px-3 py-1 bg-sky-500/20 text-sky-300 rounded-full text-sm">NA.9.6.3</span>
             <span class="px-3 py-1 bg-cyan-500/20 text-cyan-300 rounded-full text-sm">Crack Control</span>


### PR DESCRIPTION
Adds `concrete_wall_minimum_reinforcement/`, plus the audit of the source spreadsheet it grew out of.

## The idea

7.3.3(2) ties the permitted steel stress to the **bar diameter** through Table 7.2N, and that stress is the denominator of eq. (7.1). So the required area is a function of the bar you pick — small bars buy a high stress and need *less* steel. Indexing everything by diameter turns the crack requirement from a hidden constant into a priced choice.

Same wall (t 350, B35, c 35), at ø16:

| requirement | As [mm²/m per face] |
|---|---|
| detailing only, NA.9.6.3 | 674 |
| wk 0,40 | 1886 |
| wk 0,30 | 2178 |
| wk 0,20 | 2575 |
| wk 0,30, cracking at 3 d | 1635 |
| kc = 0,6 house rule | 1307 |

## What it implements

- **§9.6** — 9.6.2(1),(2),(3), 9.6.3(2), the 9.6.4 links trigger with its ø ≤ 16 waiver, and the 9.6.1(1) scope warning
- **NA.9.6.3** — `max(0,25·As,v ; k·Ac·fctm/fyk)`, k = 0,30 exterior / 0,15 interior, overridable; the code leg doubles for a single central layer
- **§7.3.2** — eq. (7.1) with an absolute yield floor, by two routes: 7.3.3 simplified (Table 7.2N, interpolated in both σs and wk) and 7.3.4 direct (full crack width, k2 = 1,0 for pure tension, solved by bisection)
- **EN 1992-3** — Tightness Class 1 wk1 from hD/h, eq. (7.122), and Table L.1 restraint factors for the zone height

## The finding

Note 1 to Table 7.2N states the table assumes **k2 = 0,5, kc = 0,4, hcr = 0,5h** — a section in *bending*. A wall under edge restraint is in *uniform tension*, k2 = 1,0 and hcr = h. Eq. (7.7N) rescales the bar size but does not restore k2 inside sr,max, so the simplified answers deliver wk ≈ 0,31–0,45 mm against a 0,30 target. 7.3.1(9) makes the routes alternatives, so both are compliant — the tool shows both and names which is which.

## Refusals rather than silent clamps

- a bar off the end of Table 7.2N is refused, not pinned at σs = 160
- no crack-width relaxation goes below `kc·k·fct,eff·Act/fyk`
- a spacing under 75 mm is reported unbuildable instead of printed
- when wk falls outside 0,20–0,40 the direct route takes over automatically, with a note

## Out of scope, stated in the README

Out-of-plane bending (9.6.1(1) sends that to the slab rules of §9.3) and in-plane shear walls.

## Verification

`node concrete_wall_minimum_reinforcement/test.js` — 32 vectors, including the Statens vegvesen culvert example (As,hmin 547), a Norwegian retaining-wall report (768), and parity with the source spreadsheet (2333 at σs = 240). All pass. No console errors across every mode in the browser.

## Deployment

`concrete_wall_minimum_reinforcement` added to the copy-loop allowlist in `deploy-all-modules.yml`; the `paths:` filter already matches via `concrete_*/**`. Landing-page card added beside the existing minimum reinforcement calculator. `module-registry.json` untouched — it regenerates on deploy.

Also includes `global-devspecs/concrete_wall_minimum_reinforcement-plan.md`: the audit of `Minimumsarmering.xlsm!Vegg` against EC2 that this module came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
