### PR TITLE
feat(wall-min-reinf): clearer materials, explicit k, derived vertical c/c

### DIFF
--- a/concrete_wall_minimum_reinforcement/README.md
+++ b/concrete_wall_minimum_reinforcement/README.md
@@ -38,6 +38,21 @@ And the same wall under different requirements, at ø16:
 | wk 0,30, cracking at 3 d | 1635 |
 | kc = 0,6 house rule | 1307 |
 
+## Defaults, and how little you should have to type
+
+The page opens on the commonest case and computes the rest, so a first answer needs no
+interaction at all: **ordinary wall**, **no crack requirement**, **exterior wall**,
+**ø12**, two layers, t = 350, B35, fₕₖ = 500, cover 35.
+
+The **vertical bar c/c is derived, not entered**. Left on *auto* it is the widest spacing of
+the chosen bar that still meets the governing vertical requirement — the minimum
+reinforcement — rounded down to 5 mm and capped by 9.6.2(3). ø12 in a 350 wall gives c320.
+Type any spacing to take over; the *auto* chip hands it back.
+
+Browsers restore form state across reloads, which for a calculator silently changes the
+answer. Every control is therefore written back to its default on load, so a fresh visit
+always starts from the values above. Only the report's project metadata persists.
+
 ## Printable record
 
 **Print / PDF** in the header renders a separate one-page A4 sheet and opens the browser
@@ -157,6 +172,11 @@ number on the adjacent row, and says plainly which is which.
   rule, and the tool labels it as such. Enter L and H to get the EN 1992-3 Table L.1 second
   opinion, which keys off L/H rather than thickness and will flag long walls where 3t is
   unconservative.
+- **k in NA.9.6.3(1)** is shown in its own read-only field next to the wall side, spelled
+  out as *0,30 — exterior wall (yttervegg)*, because it doubles the horizontal minimum and
+  was previously invisible. Override it under Assumptions.
+- **The c/c rows in both matrices are editable.** Type 225, or anything else you want to
+  check, and that row appears in both directions.
 - **Cover** is the cover to the horizontal bar. 9.6.3 puts those at the surface, and in a
   wall they are normally the outer layer for exactly that reason.
 - **fctm** uses the closed form `0,30·fck^(2/3)`, not the rounded Table 3.1 value, so results

--- a/concrete_wall_minimum_reinforcement/index.html
+++ b/concrete_wall_minimum_reinforcement/index.html
@@ -73,6 +73,21 @@
     #tip em { color:#7dd3fc; font-style:normal; }
     .lbl[data-tip] { text-decoration:underline dotted #44607f; text-underline-offset:3px; cursor:help; }
     .tiphint { font-size:.68rem; color:#5c6b82; }
+    /* Unit suffix inside a field, so thickness, concrete and steel all read the same way. */
+    .fldwrap { position:relative; }
+    .fldwrap .unit { position:absolute; right:.45rem; top:50%; transform:translateY(-50%);
+                     font-size:.7rem; color:#5c6b82; pointer-events:none; }
+    .fldwrap input { padding-right:2.4rem; }
+    .fld.ro { color:#a8b8cd; background:#0d1526; cursor:default; }
+    .fld.autoval { border-color:#0e7490; }
+    .ccin { width:3.3rem; background:#0b1120; border:1px solid #2c3d5a; border-radius:.25rem;
+            padding:.1rem .3rem; color:#a8b8cd; font-size:.78rem; text-align:right;
+            font-variant-numeric:tabular-nums; }
+    .ccin:hover { border-color:#44607f; }
+    .ccin:focus { outline:none; border-color:#38bdf8; color:#e6edf6; }
+    .derived { font-size:.72rem; color:#7f92ad; }
+    .derived b { color:#c3d3e6; font-weight:600; }
+
     #reportRoot { display:none; }
 
     @media print {
@@ -155,12 +170,12 @@
   </div>
 
   <!-- ============ INPUTS ============ -->
-  <div class="panel p-3 mb-3">
+  <div class="panel p-3 mb-3" id="inputPanel">
 
     <div class="flex flex-wrap items-center gap-2 mb-3">
       <span class="lbl mb-0 mr-1">Situation</span>
-      <button class="pill" data-mode="ordinary">Ordinary wall</button>
-      <button class="pill on" data-mode="onBase">Wall on base</button>
+      <button type="button" class="pill on" data-mode="ordinary">Ordinary wall</button>
+      <button type="button" class="pill" data-mode="onBase">Wall on base</button>
       <button class="pill" data-mode="watertight">Watertight</button>
       <label class="flex items-center gap-1.5 text-xs text-slate-300 ml-2">
         <input type="checkbox" id="rtb" class="accent-sky-500"> also restrained top and bottom
@@ -169,29 +184,44 @@
       <span class="tiphint w-full">Hover any control to see what it changes in the calculation.</span>
     </div>
 
-    <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2 mb-3">
-      <div><span class="lbl">Thickness t</span><input id="t" class="fld" value="350"></div>
-      <div><span class="lbl">Concrete</span>
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+      <div><span class="lbl">Wall thickness</span>
+        <div class="fldwrap"><input id="t" class="fld" inputmode="numeric" value="350"><span class="unit">mm</span></div></div>
+      <div><span class="lbl">Concrete class</span>
         <select id="fck" class="fld">
-          <option>20</option><option>25</option><option>30</option><option selected>35</option>
-          <option>40</option><option>45</option><option>50</option><option>55</option><option>60</option>
+          <option value="20">B20</option><option value="25">B25</option><option value="30">B30</option>
+          <option value="35" selected>B35</option><option value="40">B40</option><option value="45">B45</option>
+          <option value="50">B50</option><option value="55">B55</option><option value="60">B60</option>
         </select></div>
-      <div><span class="lbl">f<sub>yk</sub></span><input id="fyk" class="fld" value="500"></div>
-      <div><span class="lbl">Layers</span>
+      <div><span class="lbl">Steel f<sub>yk</sub></span>
+        <div class="fldwrap"><input id="fyk" class="fld" inputmode="numeric" value="500"><span class="unit">MPa</span></div></div>
+      <div><span class="lbl">Reinforcement layers</span>
         <select id="layers" class="fld"><option value="2" selected>2 — one per face</option><option value="1">1 — central</option></select></div>
-      <div><span class="lbl">Cover c<sub>nom</sub></span><input id="cover" class="fld" value="35"></div>
-      <div><span class="lbl">Wall side</span>
-        <select id="side" class="fld"><option value="exterior" selected>Exterior (yttervegg)</option><option value="interior">Interior (innervegg)</option></select></div>
-      <div><span class="lbl">Vert. bar ø</span>
-        <select id="vdia" class="fld"><option>8</option><option>10</option><option selected>12</option><option>16</option><option>20</option><option>25</option><option>32</option></select></div>
-      <div><span class="lbl">Vert. bar cc</span><input id="vcc" class="fld" value="250"></div>
+      <div><span class="lbl">Cover c<sub>nom</sub></span>
+        <div class="fldwrap"><input id="cover" class="fld" inputmode="numeric" value="35"><span class="unit">mm</span></div></div>
     </div>
+    <div id="matLine" class="derived mt-1.5"></div>
+
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-3">
+      <div><span class="lbl">Wall side</span>
+        <select id="side" class="fld"><option value="exterior" selected>Exterior wall (yttervegg)</option><option value="interior">Interior wall (innervegg)</option></select></div>
+      <div><span class="lbl">k · NA.9.6.3(1)</span>
+        <input id="kNaBox" class="fld ro" readonly tabindex="-1" value="—"></div>
+      <div><span class="lbl">Vertical bar ø</span>
+        <select id="vdia" class="fld"><option>8</option><option>10</option><option selected>12</option><option>16</option><option>20</option><option>25</option><option>32</option></select></div>
+      <div>
+        <span class="lbl">Vertical bar c/c
+          <button type="button" class="pill sm" id="vccAuto" style="padding:0 .3rem;font-size:.62rem;vertical-align:middle">auto</button>
+        </span>
+        <div class="fldwrap"><input id="vcc" class="fld" inputmode="numeric" value="320"><span class="unit">mm</span></div></div>
+    </div>
+    <div id="vLine" class="derived mt-1.5 mb-3"></div>
 
     <div class="flex flex-wrap items-center gap-2">
       <span class="lbl mb-0 mr-1">Crack requirement</span>
-      <button class="pill" data-crack="none">None required</button>
+      <button type="button" class="pill on" data-crack="none">None required</button>
       <button class="pill" data-crack="wk040">w<sub>k</sub> 0,40</button>
-      <button class="pill on" data-crack="wk030">w<sub>k</sub> 0,30</button>
+      <button type="button" class="pill" data-crack="wk030">w<sub>k</sub> 0,30</button>
       <button class="pill" data-crack="wk020">w<sub>k</sub> 0,20</button>
       <button class="pill" data-crack="watertight">Watertight</button>
       <button class="pill" data-crack="custom">Custom</button>
@@ -220,6 +250,8 @@
           <select id="kMode" class="fld"><option value="external" selected>1,0 external restraint</option><option value="ec2h">EC2 h-interpolation</option></select></div>
         <div><span class="lbl">Cracking at</span>
           <select id="age" class="fld"><option value="28" selected>28 days</option><option value="7">7 days</option><option value="3">3 days</option></select></div>
+        <div><span class="lbl">k override · NA.9.6.3</span>
+          <input id="kNaOverride" class="fld" placeholder="0,30 / 0,15"></div>
         <div><span class="lbl">Cement</span>
           <select id="cement" class="fld"><option value="N" selected>CEM N</option><option value="R">CEM R</option><option value="S">CEM S</option></select></div>
         <div><span class="lbl">Wall length L</span><input id="wallL" class="fld" placeholder="optional"></div>
@@ -288,14 +320,24 @@
       </div>
 
       <div class="panel p-3">
-        <div class="flex items-center justify-between mb-2">
+        <div class="flex items-center justify-between mb-2 gap-3 flex-wrap">
           <span class="lbl mb-0">A<sub>s</sub> provided [mm²/m] · green = meets the requirement for that bar</span>
-          <div class="flex gap-1">
-            <button class="pill sm on" data-dir="h">Horizontal</button>
-            <button class="pill sm" data-dir="v">Vertical</button>
+          <div class="flex items-center gap-1">
+            <span class="text-xs text-slate-500 mr-1">c/c values are editable — type any spacing</span>
+            <button type="button" class="pill sm" id="addRow">+ row</button>
+            <button type="button" class="pill sm" id="resetRows">reset</button>
           </div>
         </div>
-        <div class="overflow-x-auto"><table class="grid w-full" id="matrix"></table></div>
+        <div class="grid gap-4 herosplit" style="grid-template-columns:1fr 1fr">
+          <div>
+            <div class="lbl" id="matHeadH">Horizontal · each face</div>
+            <div class="overflow-x-auto"><table class="grid w-full" id="matrixH"></table></div>
+          </div>
+          <div>
+            <div class="lbl" id="matHeadV">Vertical · each face</div>
+            <div class="overflow-x-auto"><table class="grid w-full" id="matrixV"></table></div>
+          </div>
+        </div>
         <div class="flex flex-wrap gap-3 mt-2 text-xs text-slate-500">
           <span><span class="inline-block w-3 h-3 rounded-sm align-middle c-ok"></span> meets</span>
           <span><span class="inline-block w-3 h-3 rounded-sm align-middle c-near"></span> within 5 %</span>

--- a/concrete_wall_minimum_reinforcement/script.js
+++ b/concrete_wall_minimum_reinforcement/script.js
@@ -6,13 +6,29 @@
   const $ = (id) => document.getElementById(id);
   const API = () => window.WallMinReinf;
 
+  const DEFAULT_SPACINGS = [75, 100, 125, 150, 200, 250, 300, 400];
+
+  /* Everything the page opens with. initDefaults() writes these into the DOM on every
+     load, so a browser restoring old form values cannot change what a fresh visit sees. */
+  const DEFAULTS = {
+    mode: 'ordinary', crackReq: 'none', selectedDia: 12, diaAuto: false, vAuto: true,
+    fields: {
+      t: '350', fck: '35', fyk: '500', layers: '2', cover: '35', side: 'exterior',
+      vdia: '12', wkCustom: '0.30', cnom: '35', cmindur: '25', hD: '2000',
+      kcMode: 'pureTension', kcCustom: '1.0', kMode: 'external', kNaOverride: '',
+      age: '28', cement: 'N', wallL: '', wallH: '', epsFree: '320', epsCtu: '100'
+    },
+    checks: { rtb: false, uplift: false }
+  };
+
   const state = {
-    mode: 'onBase',
-    crackReq: 'wk030',
-    selectedDia: 16,
-    diaAuto: true,          // until the user picks a bar themselves
+    mode: DEFAULTS.mode,
+    crackReq: DEFAULTS.crackReq,
+    selectedDia: DEFAULTS.selectedDia,
+    diaAuto: DEFAULTS.diaAuto,   // false: ø12 is the standard choice, auto is opt-in
+    vAuto: DEFAULTS.vAuto,       // vertical c/c follows the minimum until typed over
     method: 'simplified',
-    matrixDir: 'h'
+    spacings: DEFAULT_SPACINGS.slice()
   };
 
   const n = (v) => {
@@ -21,6 +37,8 @@
   };
   const fmt = (v, dp) => (v == null || !isFinite(v)) ? '—' : v.toFixed(dp).replace('.', ',');
   const esc = (s) => String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+  const group = (v) => (v == null || !isFinite(v)) ? '—'
+    : Math.round(v).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
 
   // ------------------------------------------------------------------ inputs
 
@@ -34,7 +52,8 @@
       layers: n($('layers').value),
       cover: n($('cover').value),
       exposureSide: $('side').value,
-      vBar: { dia: n($('vdia').value), spacing: n($('vcc').value) },
+      kNaOverride: ($('kNaOverride').value || '').trim() === '' ? null : n($('kNaOverride').value),
+      vBar: { dia: n($('vdia').value), spacing: n($('vcc').value) || 250 },
       crackReq: state.crackReq,
       wkCustom: n($('wkCustom').value),
       naCoverUplift: { on: $('uplift').checked, cnom: n($('cnom').value), cminDur: n($('cmindur').value) },
@@ -96,9 +115,25 @@
     return null;
   }
 
+  /* The widest spacing of the chosen vertical bar that still meets the governing vertical
+     requirement, rounded down to 5 mm and capped by 9.6.2(3). The vertical requirement is a
+     flat area, independent of the bar, so one extra pass settles it. */
+  function autoVcc(r) {
+    const dia = r.inputs.vBar.dia;
+    const byArea = 1000 * Math.PI * dia * dia / 4 / r.governing.vertical.As;
+    return Math.max(50, Math.floor(Math.min(byArea, r.detailing.sVMax) / 5) * 5);
+  }
+
   function render() {
     syncVisibility();
     let r = API().calculate(readInputs());
+    if (state.vAuto) {
+      const cc = autoVcc(r);
+      if (String(cc) !== $('vcc').value) {
+        $('vcc').value = cc;
+        r = API().calculate(readInputs());
+      }
+    }
     if (state.diaAuto) {
       const best = autoDia(r);
       if (best != null && best !== state.selectedDia) {
@@ -120,6 +155,7 @@
       b.style.opacity = forced && b.dataset.method === 'simplified' ? '.35' : '';
       b.title = forced ? 'Table 7.2N does not span this crack width — the direct route is the only one available' : '';
     });
+    paintDerived(r);
     paintDiaPicker(dias, r);
     paintHeadline(r);
     paintGovBars(r);
@@ -131,9 +167,38 @@
     buildReport(r);
   }
 
+  /* Thickness, concrete and steel each stated the same way, with what they produce. */
+  function paintDerived(r) {
+    const i = r.inputs;
+    $('matLine').innerHTML =
+      't = <b>' + fmt(i.t, 0) + ' mm</b>' +
+      ' &nbsp;\u00b7&nbsp; A<sub>c</sub> = <b>' + group(r.detailing.Ac) + ' mm\u00b2/m</b>' +
+      ' &nbsp;\u00b7&nbsp; <b>B' + fmt(i.fck, 0) + '</b> \u2192 f<sub>ctm</sub> = <b>' + fmt(r.material.fctm, 2) + ' MPa</b>' +
+      ' &nbsp;\u00b7&nbsp; <b>f<sub>yk</sub> = ' + fmt(i.fyk, 0) + ' MPa</b>' +
+      (i.fyk === 500 ? ' (B500NC)' : '') +
+      ' &nbsp;\u00b7&nbsp; ' + (i.layers === 2 ? 'two layers, one per face' : 'one central layer') +
+      ' &nbsp;\u00b7&nbsp; cover <b>' + fmt(i.cover, 0) + ' mm</b>';
+
+    const side = i.exposureSide === 'exterior' ? 'exterior wall (yttervegg)' : 'interior wall (innervegg)';
+    const overridden = i.kNaOverride != null;
+    $('kNaBox').value = fmt(r.detailing.kNA, 2) + '  \u2014  ' + (overridden ? 'user override' : side);
+    $('kNaBox').classList.toggle('autoval', overridden);
+
+    $('vLine').innerHTML =
+      'A<sub>s,hmin</sub> = max(25 % of A<sub>s,v</sub> = <b>' + fmt(r.detailing.quarterLeg, 0) +
+      '</b>; k\u00b7A<sub>c</sub>\u00b7f<sub>ctm</sub>/f<sub>yk</sub> = <b>' + fmt(r.detailing.naLeg, 0) +
+      '</b>) = <b>' + fmt(r.detailing.AsHMin, 0) + ' mm\u00b2/m</b> per face' +
+      ' &nbsp;\u00b7&nbsp; vertical \u00f8' + i.vBar.dia + ' c' + fmt(i.vBar.spacing, 0) + ' gives <b>' +
+      fmt(r.detailing.AsVProv, 0) + '</b> against <b>' + fmt(r.governing.vertical.As, 0) + '</b> required' +
+      (state.vAuto ? ' &nbsp;\u00b7&nbsp; <span class="text-sky-400">c/c set automatically to the minimum</span>' : '');
+    $('vcc').classList.toggle('autoval', state.vAuto);
+    $('vccAuto').classList.toggle('on', state.vAuto);
+  }
+
   function paintDiaPicker(dias, r) {
-    $('diaPicker').innerHTML = (state.diaAuto ? '' :
-      '<button class="pill sm" data-dia="auto" title="return to the automatic pick">auto</button>') +
+    $('diaPicker').innerHTML =
+      '<button class="pill sm ' + (state.diaAuto ? 'on' : '') + '" data-dia="auto"' +
+      ' title="let the tool pick the cheapest buildable bar">auto</button>' +
       dias.map(d => {
       const list = r.crack.methodEffective === 'direct' ? r.crack.barsDirect : r.crack.bars;
       const b = list.find(x => x.dia === d);
@@ -343,8 +408,12 @@
   }
 
   function paintMatrix(r, dias) {
-    const spacings = r.constants.SPACINGS;
-    const vertical = state.matrixDir === 'v';
+    paintOneMatrix('matrixH', r, dias, false);
+    paintOneMatrix('matrixV', r, dias, true);
+  }
+
+  function paintOneMatrix(id, r, dias, vertical) {
+    const spacings = state.spacings;
     const cap = vertical ? r.detailing.sVMax : r.detailing.sHMax;
 
     const need = dias.map(d => {
@@ -352,43 +421,63 @@
       if (!r.crack.active) return r.detailing.AsHMin;
       const list = r.crack.methodEffective === 'direct' ? r.crack.barsDirect : r.crack.bars;
       const b = list.find(x => x.dia === d);
-      if (!b || b.AsReq == null) return null;                 // bar not permitted at this wk
+      if (!b || b.AsReq == null) return null;               // bar not permitted at this wk
       return Math.max(b.AsReq, r.detailing.AsHMin);
     });
 
-    // cheapest (largest) spacing that still works, per column
+    // cheapest (widest) spacing that still works, per column
     const best = dias.map((d, i) => {
       if (need[i] == null) return null;
       let pick = null;
-      for (const s of spacings) {
-        if (s > cap) continue;
-        if (API().area(d, s) >= need[i]) pick = s;
+      for (const sp of spacings) {
+        if (sp > cap) continue;
+        if (API().area(d, sp) >= need[i]) pick = sp;
       }
       return pick;
     });
 
-    let html = '<tr><th style="text-align:left">c/c ↓  ø →</th>' +
+    let html = '<tr><th style="text-align:left">c/c \u2193  \u00f8 \u2192</th>' +
       dias.map(d => '<th>' + d + '</th>').join('') + '</tr>';
     html += '<tr><td style="text-align:left;color:#7f92ad">required</td>' +
-      need.map(v => '<td style="color:#cbd5e1">' + (v == null ? '—' : fmt(v, 0)) + '</td>').join('') + '</tr>';
+      need.map(v => '<td style="color:#cbd5e1">' + (v == null ? '\u2014' : fmt(v, 0)) + '</td>').join('') + '</tr>';
 
-    for (const s of spacings) {
-      html += '<tr><td style="text-align:left;color:#7f92ad">c' + s + '</td>';
+    spacings.forEach((sp, rowIx) => {
+      html += '<tr><td style="text-align:left;padding-right:.2rem">' +
+        '<input class="ccin" data-row="' + rowIx + '" data-grid="' + id + '" value="' + sp + '" inputmode="numeric">' +
+        '</td>';
       dias.forEach((d, i) => {
-        const As = API().area(d, s);
+        const As = API().area(d, sp);
         let cls = 'c-ok', title = '';
-        if (s > cap) { cls = 'c-cap'; title = 'spacing exceeds the code maximum c' + cap; }
-        else if (need[i] == null) { cls = 'c-veto'; title = 'ø' + d + ' is not permitted at this crack width'; }
+        if (sp > cap) { cls = 'c-cap'; title = 'spacing exceeds the code maximum c' + cap; }
+        else if (need[i] == null) { cls = 'c-veto'; title = '\u00f8' + d + ' is not permitted at this crack width'; }
         else if (As >= need[i]) cls = 'c-ok';
         else if (As >= 0.95 * need[i]) cls = 'c-near';
         else cls = 'c-bad';
-        const mark = (best[i] === s && s <= cap) ? ' ◇' : '';
-        html += '<td class="' + cls + (best[i] === s && s <= cap ? ' c-pick' : '') + '" title="' + title + '">' +
-          fmt(As, 0) + mark + '</td>';
+        const isBest = best[i] === sp && sp <= cap;
+        html += '<td class="' + cls + (isBest ? ' c-pick' : '') + '" title="' + title + '">' +
+          fmt(As, 0) + (isBest ? ' \u25c7' : '') + '</td>';
       });
       html += '</tr>';
-    }
-    $('matrix').innerHTML = html;
+    });
+    $(id).innerHTML = html;
+
+    $(id).querySelectorAll('.ccin').forEach(el => {
+      el.addEventListener('change', () => {
+        const v = Math.round(n(el.value));
+        if (!isFinite(v) || v < 25 || v > 900) { render(); return; }
+        const next = state.spacings.slice();
+        next[parseInt(el.dataset.row, 10)] = v;
+        state.spacings = dedupeSorted(next);
+        render();
+      });
+      el.addEventListener('keydown', e => { if (e.key === 'Enter') el.blur(); });
+    });
+  }
+
+  function dedupeSorted(arr) {
+    return arr.filter(v => isFinite(v) && v > 0)
+      .filter((v, i, a) => a.indexOf(v) === i)
+      .sort((a, b) => a - b);
   }
 
   function paintChecks(r) {
@@ -538,6 +627,21 @@
     'dir.v': ['Vertical bars',
       'One threshold for every column \u2014 0,002\u00b7A<sub>c</sub> split between the faces \u2014 and the ' +
       'spacing cap tightens to min(3t, 400).'],
+    'f.kNA': ['k in NA.9.6.3(1)',
+      'The factor in the code leg of the horizontal minimum, k·A<sub>c</sub>·f<sub>ctm</sub>/f<sub>yk</sub>. ' +
+      'NA.9.6.3(1) sets it at <em>0,30 for an exterior wall</em> and <em>0,15 for an interior one</em>. ' +
+      'The 0,15 is not a halving — across B25 to B45 it works out at 0,08 to 0,11 % of the section, which is ' +
+      'EC2’s own recommended 0,001·A<sub>c</sub> re-expressed so it scales with the cracking force. 0,30 is ' +
+      'the deliberate doubling for outdoor exposure. Override it under Assumptions if your case needs it.'],
+    'f.vcc': ['Vertical bar spacing',
+      'Left on <em>auto</em> this is the widest spacing of the chosen bar that still meets the governing vertical ' +
+      'requirement — the minimum reinforcement, in other words — rounded down to 5 mm and capped by ' +
+      '9.6.2(3). Type any spacing to take over; the auto button hands it back. What you set here also feeds the ' +
+      '“25 % of the vertical reinforcement” leg of NA.9.6.3.'],
+    'f.rows': ['Spacing rows',
+      'The c/c values down the left of both matrices are editable. Type 225, or any other spacing you want to ' +
+      'check, and that row appears in both directions. <b>+ row</b> adds one, <b>reset</b> restores the standard ' +
+      'set. Rows sort themselves and duplicates are dropped.'],
     'diaPicker': ['Bar size',
       'The tool starts on the cheapest buildable bar. Pick another and the headline follows it; press ' +
       '\u201cauto\u201d to hand the choice back.']
@@ -551,7 +655,9 @@
     ['[data-crack="wk030"]', 'crack.wk030'], ['[data-crack="wk020"]', 'crack.wk020'],
     ['[data-crack="watertight"]', 'crack.watertight'], ['[data-crack="custom"]', 'crack.custom'],
     ['[data-method="simplified"]', 'method.simplified'], ['[data-method="direct"]', 'method.direct'],
-    ['[data-dir="h"]', 'dir.h'], ['[data-dir="v"]', 'dir.v'],
+    ['#matHeadH', 'dir.h'], ['#matHeadV', 'dir.v'],
+    ['#kNaBox', 'f.kNA', 'parent'], ['#vcc', 'f.vcc', 'parent'], ['#vccAuto', 'f.vcc'],
+    ['#addRow', 'f.rows'], ['#resetRows', 'f.rows'], ['#kNaOverride', 'f.kNA', 'parent'],
     ['#rtb', 'rtb', 'parent'], ['#upliftWrap', 'uplift'],
     ['#t', 'f.t', 'parent'], ['#fck', 'f.fck', 'parent'], ['#fyk', 'f.fyk', 'parent'],
     ['#layers', 'f.layers', 'parent'], ['#cover', 'f.cover', 'parent'], ['#side', 'f.side', 'parent'],
@@ -841,11 +947,19 @@
       render();
     }));
 
-    document.querySelectorAll('[data-dir]').forEach(b => b.addEventListener('click', () => {
-      state.matrixDir = b.dataset.dir;
-      document.querySelectorAll('[data-dir]').forEach(x => x.classList.toggle('on', x === b));
+    $('addRow').addEventListener('click', () => {
+      const last = state.spacings[state.spacings.length - 1] || 100;
+      state.spacings = dedupeSorted(state.spacings.concat([Math.min(900, last + 50)]));
       render();
-    }));
+    });
+    $('resetRows').addEventListener('click', () => {
+      state.spacings = DEFAULT_SPACINGS.slice();
+      render();
+    });
+
+    $('vccAuto').addEventListener('click', () => { state.vAuto = true; render(); });
+    $('vcc').addEventListener('input', () => { state.vAuto = false; });
+    $('vdia').addEventListener('change', () => { render(); });
 
     $('diaPicker').addEventListener('click', (e) => {
       const b = e.target.closest('[data-dia]');
@@ -857,16 +971,33 @@
     });
 
     ['t', 'fck', 'fyk', 'layers', 'cover', 'side', 'vdia', 'vcc', 'rtb', 'uplift', 'cnom', 'cmindur',
-      'hD', 'wkCustom', 'kcMode', 'kcCustom', 'kMode', 'age', 'cement', 'wallL', 'wallH', 'epsFree', 'epsCtu']
+      'hD', 'wkCustom', 'kcMode', 'kcCustom', 'kMode', 'kNaOverride', 'age', 'cement', 'wallL', 'wallH',
+      'epsFree', 'epsCtu']
       .forEach(id => {
         const el = $(id);
         el.addEventListener('input', render);
         el.addEventListener('change', render);
       });
 
+    initDefaults();
     initTips();
     initMeta();
     render();
+  }
+
+  /* Browsers restore form state across reloads. For a calculator that silently changes
+     the answer, so every control is written back to its default on load. */
+  function initDefaults() {
+    Object.keys(DEFAULTS.fields).forEach(id => { if ($(id)) $(id).value = DEFAULTS.fields[id]; });
+    Object.keys(DEFAULTS.checks).forEach(id => { if ($(id)) $(id).checked = DEFAULTS.checks[id]; });
+    state.mode = DEFAULTS.mode;
+    state.crackReq = DEFAULTS.crackReq;
+    state.selectedDia = DEFAULTS.selectedDia;
+    state.diaAuto = DEFAULTS.diaAuto;
+    state.vAuto = DEFAULTS.vAuto;
+    state.spacings = DEFAULT_SPACINGS.slice();
+    document.querySelectorAll('[data-mode]').forEach(b => b.classList.toggle('on', b.dataset.mode === state.mode));
+    document.querySelectorAll('[data-crack]').forEach(b => b.classList.toggle('on', b.dataset.crack === state.crackReq));
   }
 
   function setCrack(v) {


### PR DESCRIPTION
**Not for merging yet** — this is here so you can look at it. The dev server is serving this branch from the working tree, so just reload http://localhost:8080/structural_tools/concrete_wall_minimum_reinforcement/

## 1. Thickness, concrete and steel presented alike

They sat side by side as `350`, `35`, `500` with nothing to say what any of them meant. Now each field carries its unit inside the box, the concrete select reads **B35** rather than 35, and a derived line under the row states what they produce:

> t = **350 mm** · A_c = **350 000 mm²/m** · **B35** → f_ctm = **3,21 MPa** · **f_yk = 500 MPa** (B500NC) · two layers, one per face · cover **35 mm**

## 2. k has its own explanatory field

Next to Wall side, read-only: **`0,30 — exterior wall (yttervegg)`**. It doubles the horizontal minimum and was nowhere on the page. A numeric override sits under Assumptions, and the field reads *user override* when it's in use. A second derived line spells out the whole leg:

> A_s,hmin = max(25 % of A_s,v = **88**; k·A_c·f_ctm/f_yk = **674**) = **674 mm²/m** per face

## 3–5. Defaults are the commonest case

**Ordinary wall**, **no crack requirement**, **exterior wall**, **ø12**. A first answer now needs zero interaction.

## 6. Vertical c/c is derived, not typed

On *auto* it's the widest spacing of the chosen bar that still meets the governing vertical requirement — the minimum reinforcement — rounded down to 5 mm and capped by 9.6.2(3). **ø12 in a 350 wall gives c320**, straight off the vertical table you circled. Type any spacing to take over; the *auto* chip hands it back. Safe from circularity because the vertical requirement is a flat area independent of the bar, so one extra pass settles it.

## 7. Two matrices, both labelled

The provided-area matrix never said which direction it showed. There are now two, side by side and titled **Horizontal · each face** / **Vertical · each face**, sharing one spacing list so the rows line up. The direction toggle is gone.

## 8. Editable c/c rows

The values down the left of both matrices are inputs. Type **225** and that row appears in both directions. Rows re-sort, duplicates drop, `+ row` and `reset` handle the rest.

## 9. Fresh load always gives the standard values

Browsers restore form state across reloads, which for a calculator silently changes the answer — it's why your screenshot showed *Interior* selected. Every control is now written back to its default on load. Only the report's project metadata persists.

## Verified

Report still fits one A4 page in every mode (207–259 mm against 275 available) · 32 tooltips resolve, including new ones for k, the vertical c/c and the editable rows · 32 API tests pass · no console errors · no horizontal overflow.

No calculation changes — `wall_min_reinf_api.js` is untouched. No workflow or 2dfea changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
