### PR TITLE
feat(clustering): per-cluster statistics table

### DIFF
--- a/clustering/README.md
+++ b/clustering/README.md
@@ -86,6 +86,27 @@ Compressed to a 0,4 power so the shape reads — the raw curve collapses so stee
 every bar past k = 2 would be flat. Clicking a bar sets k. It is advisory and labelled
 as such.
 
+## Cluster statistics
+
+A second table below the results gives one row per cluster and an "All" row: n and
+share, min, max, mean, median, sd, band width, the gap to the next cluster, and two
+derived numbers worth explaining.
+
+**density** is the cluster's share of the rows divided by its share of the value axis.
+Deliberately dimensionless — raw points-per-unit means nothing without knowing the
+units and changes the moment the column is rescaled, whereas a share-over-share ratio
+does not. `1,0×` is exactly as dense as an even spread, higher is tighter, below `1,0×`
+is more strung out. Zero-width bands report `—` rather than dividing by zero.
+
+**silhouette** is the standard cluster-quality number: how much closer a point sits to
+its own cluster than to the nearest other one, in [−1, 1]. 1 is cleanly separated, 0 is
+on the boundary, negative means probably in the wrong cluster. Computed with prefix sums
+over the sorted groups, so the whole table costs `O(n·k·log n)` rather than `O(n²)`.
+
+The "All" row adds the share of total spread the clustering accounts for, `1 − WCSS/TSS`.
+If the weakest cluster drops below a silhouette of 0,5 the note says so and suggests
+checking k. Copy the whole table as TSV with one button.
+
 ## Output
 
 - **Copy for Excel (TSV)** — the inverse of the paste-in path
@@ -104,4 +125,4 @@ They are never silently dropped.
 | `script.js` | form reading, chart painting, hover |
 | `index.html` | single-page UI |
 | `SPEC.md` | the contract, with the defect list it was written against |
-| `test.js` | 49 verification vectors — `node test.js` |
+| `test.js` | 70 verification vectors — `node test.js` |

--- a/clustering/README.md
+++ b/clustering/README.md
@@ -104,8 +104,17 @@ on the boundary, negative means probably in the wrong cluster. Computed with pre
 over the sorted groups, so the whole table costs `O(n·k·log n)` rather than `O(n²)`.
 
 The "All" row adds the share of total spread the clustering accounts for, `1 − WCSS/TSS`.
-If the weakest cluster drops below a silhouette of 0,5 the note says so and suggests
-checking k. Copy the whole table as TSV with one button.
+Copy the whole table as TSV with one button.
+
+**Every metric is explained at the bottom of the page** — what it measures, how to read a
+typical value, and which of three questions it answers: *is k right?* (silhouette and the
+elbow, never the percentage of spread, which rises with k by construction), *is this band
+a real group?* (its gap against the widths either side), *is this band too loose?*
+(density near 1,0× with a large width).
+
+The note under the table is dynamic rather than boilerplate: it names the weakest band if
+one is below 0,5 silhouette, names any band sparser than an even spread, and otherwise
+points at the widest band as the next candidate for splitting.
 
 ## Output
 

--- a/clustering/SPEC.md
+++ b/clustering/SPEC.md
@@ -163,6 +163,33 @@ and fixes C3. Output column is `Cluster` (integer), plus `ClusterMin`,
 For each cluster: `n`, `min`, `max`, `mean`, `range`, and the break value to the
 next cluster (the midpoint between this cluster's max and the next cluster's min).
 
+### 4.3b Per-cluster statistics table
+
+Below the results table, one row per cluster plus an "All" row:
+
+| column | meaning |
+|---|---|
+| n, % rows | size and share |
+| min, max, mean, median, sd | the usual descriptives |
+| width | `max − min`, how much of the value axis the band occupies |
+| gap → | distance from this cluster's max to the next cluster's min — a large gap is a clean break |
+| **density** | share of rows ÷ share of the value axis |
+| **silhouette** | mean of `(b − a)/max(a, b)` per point, a = mean distance within its own cluster, b = mean distance to the nearest other |
+
+`density` is deliberately **dimensionless**. Raw points-per-unit says nothing without
+knowing the units, and changes if the column is rescaled; a share-over-share ratio does
+not. `1,0×` means exactly as dense as an even spread across the same axis, higher is
+tighter, below `1,0×` is more strung out. A zero-width band — any singleton — reports
+`—` rather than dividing by zero.
+
+`silhouette` is computed with prefix sums over the sorted groups, so a mean absolute
+distance to any cluster costs `O(log m)` rather than a scan: the whole table is
+`O(n·k·log n)`, not `O(n²)`. Singletons score 0 by convention.
+
+The "All" row carries the overall descriptives plus **the share of total spread the
+clustering accounts for**, `1 − WCSS/TSS`, and the n-weighted mean silhouette. When the
+weakest cluster falls below a silhouette of 0,5 the note says so and suggests checking k.
+
 ### 4.4 Choosing k
 
 A compact strip showing within-cluster sum of squares for k = 1…10, normalised to

--- a/clustering/cluster_api.js
+++ b/clustering/cluster_api.js
@@ -316,15 +316,120 @@
     return { assign, breaks, centroids, wcss: res.wcss, method, k };
   }
 
+  /** Mean |x - xi| over a sorted group, via prefix sums. O(log m). */
+  function meanAbsDist(x, sorted, prefix, excludeSelf) {
+    const m = sorted.length;
+    if (!m) return Infinity;
+    let lo = 0, hi = m;
+    while (lo < hi) { const mid = (lo + hi) >> 1; if (sorted[mid] <= x) lo = mid + 1; else hi = mid; }
+    const below = lo, sumBelow = prefix[lo], sumAll = prefix[m];
+    const total = (below * x - sumBelow) + ((sumAll - sumBelow) - (m - below) * x);
+    const denom = excludeSelf ? m - 1 : m;
+    return denom > 0 ? total / denom : 0;
+  }
+
+  /**
+   * Per-cluster descriptive and shape statistics.
+   *
+   * `density` is the one worth explaining: the cluster's share of the rows divided by
+   * its share of the value axis. It is dimensionless, so it survives any change of
+   * units, and 1,0 means "exactly as dense as an even spread would be". Raw points per
+   * unit would say nothing without knowing the units.
+   *
+   * `silhouette` is the standard cluster-quality number: for each point, how much
+   * closer it sits to its own cluster than to the nearest other one, in [-1, 1].
+   * Singletons are 0 by convention.
+   */
   function clusterStats(values, assign, k) {
+    const N = values.length;
+    const groups = [];
+    for (let j = 0; j < k; j++) groups.push([]);
+    values.forEach((v, i) => { const c = assign[i]; if (c >= 1 && c <= k) groups[c - 1].push(v); });
+    groups.forEach(g => g.sort((a, b) => a - b));
+
+    const prefixes = groups.map(g => {
+      const pre = new Float64Array(g.length + 1);
+      for (let i = 0; i < g.length; i++) pre[i + 1] = pre[i] + g[i];
+      return pre;
+    });
+
+    const allMin = N ? Math.min.apply(null, values) : null;
+    const allMax = N ? Math.max.apply(null, values) : null;
+    const totalWidth = (allMax != null && allMin != null) ? allMax - allMin : 0;
+
     const out = [];
-    for (let j = 1; j <= k; j++) {
-      const v = values.filter((_, i) => assign[i] === j);
-      if (!v.length) { out.push({ id: j, n: 0, min: null, max: null, mean: null, range: null }); continue; }
-      const min = Math.min.apply(null, v), max = Math.max.apply(null, v);
-      out.push({ id: j, n: v.length, min, max, mean: v.reduce((a, b) => a + b, 0) / v.length, range: max - min });
+    for (let j = 0; j < k; j++) {
+      const g = groups[j], n = g.length;
+      if (!n) {
+        out.push({ id: j + 1, n: 0, share: 0, min: null, max: null, mean: null, median: null,
+          sd: null, range: null, width: null, spanShare: null, density: null,
+          gapNext: null, silhouette: null, wcss: 0 });
+        continue;
+      }
+      const min = g[0], max = g[n - 1];
+      const mean = prefixes[j][n] / n;
+      const median = n % 2 ? g[(n - 1) / 2] : (g[n / 2 - 1] + g[n / 2]) / 2;
+      let ss = 0;
+      for (const v of g) ss += (v - mean) * (v - mean);
+      const sd = n > 1 ? Math.sqrt(ss / (n - 1)) : 0;
+      const width = max - min;
+      const share = n / N;
+      const spanShare = totalWidth > 0 ? width / totalWidth : null;
+      // a zero-width band has no meaningful density - report it rather than dividing by zero
+      const density = (spanShare != null && spanShare > 0) ? share / spanShare : null;
+
+      let sil = 0;
+      if (n > 1) {
+        let acc = 0;
+        for (const x of g) {
+          const a = meanAbsDist(x, g, prefixes[j], true);
+          let b = Infinity;
+          for (let o = 0; o < k; o++) {
+            if (o === j || !groups[o].length) continue;
+            const d = meanAbsDist(x, groups[o], prefixes[o], false);
+            if (d < b) b = d;
+          }
+          if (!isFinite(b)) { acc += 0; continue; }
+          const denom = Math.max(a, b);
+          acc += denom > 0 ? (b - a) / denom : 0;
+        }
+        sil = acc / n;
+      }
+
+      out.push({ id: j + 1, n, share, min, max, mean, median, sd,
+        range: width, width, spanShare, density, gapNext: null, silhouette: sil, wcss: ss });
+    }
+
+    for (let j = 0; j < k - 1; j++) {
+      if (out[j].max == null || out[j + 1].min == null) continue;
+      out[j].gapNext = out[j + 1].min - out[j].max;
     }
     return out;
+  }
+
+  /** Whole-dataset counterparts, for the total row under the per-cluster table. */
+  function overallStats(values, stats) {
+    const N = values.length;
+    if (!N) return null;
+    const sorted = values.slice().sort((a, b) => a - b);
+    const mean = values.reduce((a, b) => a + b, 0) / N;
+    let ss = 0;
+    for (const v of values) ss += (v - mean) * (v - mean);
+    const withN = stats.filter(s => s.n > 0);
+    const wcss = stats.reduce((a, s) => a + (s.wcss || 0), 0);
+    return {
+      n: N,
+      min: sorted[0],
+      max: sorted[N - 1],
+      mean,
+      median: N % 2 ? sorted[(N - 1) / 2] : (sorted[N / 2 - 1] + sorted[N / 2]) / 2,
+      sd: N > 1 ? Math.sqrt(ss / (N - 1)) : 0,
+      width: sorted[N - 1] - sorted[0],
+      wcss,
+      // how much of the raw spread the clustering removed
+      explained: ss > 0 ? 1 - wcss / ss : null,
+      silhouette: withN.length ? withN.reduce((a, s) => a + s.silhouette * s.n, 0) / N : null
+    };
   }
 
   /**
@@ -412,6 +517,6 @@
     DELIMITERS, RAMP_MAX_DISTINCT, EXACT_LIMIT,
     detectDelimiter, detectDecimal, toNumber, parseGrid, splitRow,
     detectHeaderRow, buildTable, profileColumns, colLetter,
-    clusterValues, clusterStats, elbowScan, rampFor
+    clusterValues, clusterStats, overallStats, elbowScan, rampFor
   };
 });

--- a/clustering/index.html
+++ b/clustering/index.html
@@ -116,6 +116,11 @@
                    padding:.3rem .5rem; font-weight:600; z-index:1; }
     table.res td { padding:.22rem .5rem; border-bottom:1px solid #1a2536; color:#c3d3e6;
                    white-space:nowrap; }
+    table.res td.n, table.res th.n { text-align:right; }
+    table.res tr.total td { border-top:1px solid #33496b; background:#161f33; color:#e6edf6;
+                            font-weight:600; }
+    table.res th[title] { cursor:help; text-decoration:underline dotted #44607f;
+                          text-underline-offset:3px; }
     .swatch { display:inline-block; width:.6rem; height:.6rem; border-radius:2px; margin-right:.35rem;
               vertical-align:middle; }
     .muted { color:#7f92ad; font-size:.75rem; }
@@ -225,6 +230,17 @@
       <span class="muted ml-auto" id="resultStatus"></span>
     </div>
     <div class="out"><table class="res" id="resTable"></table></div>
+  </div>
+
+  <!-- ============ 5. CLUSTER STATISTICS ============ -->
+  <div class="panel p-3 mb-3" id="statsPanel" hidden>
+    <div class="flex flex-wrap items-center gap-2 mb-2">
+      <span class="lbl mb-0 mr-1">Cluster statistics</span>
+      <button class="pill" id="copyStatsBtn">Copy stats (TSV)</button>
+      <span class="muted ml-auto" id="statsSummary"></span>
+    </div>
+    <div class="out" style="max-height:none"><table class="res" id="statsTable"></table></div>
+    <div class="muted mt-2 leading-relaxed" id="statsNote"></div>
   </div>
 
   <p class="text-xs text-slate-600 mt-4 leading-relaxed">

--- a/clustering/index.html
+++ b/clustering/index.html
@@ -124,6 +124,14 @@
     .swatch { display:inline-block; width:.6rem; height:.6rem; border-radius:2px; margin-right:.35rem;
               vertical-align:middle; }
     .muted { color:#7f92ad; font-size:.75rem; }
+    .defs { display:grid; grid-template-columns:9.5rem 1fr; gap:.45rem 1rem; margin-top:.5rem; }
+    .defs dt { color:#e6edf6; font-size:.78rem; font-weight:600; font-variant-numeric:tabular-nums; }
+    .defs dd { margin:0; color:#a8b8cd; font-size:.78rem; line-height:1.5; }
+    .defs dd b { color:#d8e4f2; }
+    .defs code { background:#0b1120; border:1px solid #22304a; border-radius:.2rem;
+                 padding:0 .25rem; font-size:.74rem; }
+    @media (max-width:700px){ .defs { grid-template-columns:1fr; gap:.15rem; }
+                              .defs dd { margin-bottom:.5rem; } }
     .warn { color:#fbbf24; }
     @media (max-width:1000px){ .two { grid-template-columns:1fr !important; } }
   </style>
@@ -241,6 +249,75 @@
     </div>
     <div class="out" style="max-height:none"><table class="res" id="statsTable"></table></div>
     <div class="muted mt-2 leading-relaxed" id="statsNote"></div>
+  </div>
+
+  <!-- ============ 6. HOW TO READ THE STATISTICS ============ -->
+  <div class="panel p-3 mb-3" id="explainPanel">
+    <span class="lbl">How to read the statistics</span>
+
+    <dl class="defs">
+      <dt>n · % rows</dt>
+      <dd>How many rows landed in each band. Wildly uneven counts usually mean either that the data
+          really is lopsided, or that k is wrong — a band of one or two points next to a band of
+          hundreds is a hint to drop k.</dd>
+
+      <dt>min · max</dt>
+      <dd>The actual limits of the band. These are the numbers you would write into a spec or a
+          drawing note: <i>group 3 covers 0,66 to 0,71</i>.</dd>
+
+      <dt>mean · median</dt>
+      <dd>Where the band sits. If they differ noticeably the band is skewed — a mean above the
+          median means a tail of high values pulling it up, and the median is then the fairer
+          summary.</dd>
+
+      <dt>sd</dt>
+      <dd>Spread inside the band, in the data’s own units. Useful for comparing like with like;
+          for comparing bands of different size, use density instead.</dd>
+
+      <dt>width</dt>
+      <dd><code>max − min</code>: how much of the value axis the band occupies. A band far wider
+          than its neighbours is doing more work than they are and is the first candidate for
+          splitting if you raise k.</dd>
+
+      <dt>gap →</dt>
+      <dd>The empty space between this band and the next. <b>This is the number that says whether a
+          split is real.</b> A gap much larger than the widths either side of it is a genuine break in
+          the data. A gap smaller than the bands’ own widths means the cut runs through a continuum
+          rather than between two groups — defensible, but a choice rather than a discovery.</dd>
+
+      <dt>density</dt>
+      <dd>The band’s share of the rows divided by its share of the value axis. Deliberately
+          <b>dimensionless</b>: points-per-unit would mean nothing without knowing the units and would
+          change the moment someone switched from kN to MN, whereas a ratio of shares does not.
+          <b>1,0×</b> is exactly as dense as an even spread across the same axis. <b>5,0×</b> is
+          five times as concentrated — a tight, well-defined group. <b>Below 1,0×</b> is sparser
+          than even: mostly empty space with a few points strung across it, which often means the band
+          is really two groups with a hole in the middle. A single point has no width, so it reports
+          <span class="muted">—</span>.</dd>
+
+      <dt>silhouette</dt>
+      <dd>For every point, how much closer it sits to its own band than to the nearest other one,
+          averaged over the band. Runs from −1 to 1.
+          <b>Above 0,7</b> strongly separated · <b>0,5 to 0,7</b> reasonable ·
+          <b>below 0,5</b> weak, the bands are effectively touching ·
+          <b>negative</b> the points are on average closer to a different band than their own, which
+          means k is wrong or the data has no group structure in this column. A lone point scores 0
+          by convention, since it has nothing to be close to.</dd>
+
+      <dt>% of total spread <span class="muted">(All row)</span></dt>
+      <dd><code>1 − within-cluster spread / total spread</code>: how much of the original variation
+          the split accounts for. <b>It always rises as k rises</b>, all the way to 100 % when every
+          point is its own cluster, so it can never justify a k on its own — read it next to the
+          elbow strip and the silhouette.</dd>
+    </dl>
+
+    <div class="mt-3 pt-2 border-t border-slate-800 muted leading-relaxed">
+      <b class="text-slate-300">Three questions these answer.</b>
+      <i>Is k right?</i> Silhouette and the elbow strip — not the percentage of spread, which rises
+      with k by construction.
+      <i>Is this band a real group?</i> Compare its <b>gap →</b> against the widths on either side.
+      <i>Is this band too loose?</i> Density near or below 1,0× together with a large width.
+    </div>
   </div>
 
   <p class="text-xs text-slate-600 mt-4 leading-relaxed">

--- a/clustering/script.js
+++ b/clustering/script.js
@@ -466,15 +466,25 @@
 
     const worst = R.stats.filter(s => s.n > 0)
       .reduce((a, b) => (a == null || b.silhouette < a.silhouette ? b : a), null);
-    $('statsNote').innerHTML =
-      '<b>density</b> is the cluster\u2019s share of the rows divided by its share of the value axis \u2014 ' +
-      'dimensionless, so it is unaffected by units. 1,0\u00d7 is exactly as dense as an even spread, ' +
-      'higher is tighter, lower is more strung out. <b>silhouette</b> runs from 1 (cleanly separated) ' +
-      'through 0 (sitting on the boundary) to negative (likely in the wrong cluster).' +
-      (worst && worst.silhouette < 0.5
-        ? ' <span class="warn">C' + worst.id + ' has the weakest separation at ' +
-          fmt(worst.silhouette, 3) + ' \u2014 worth checking whether k is right.</span>'
-        : '');
+    const widest = R.stats.filter(s => s.n > 0)
+      .reduce((a, b) => (a == null || b.width > a.width ? b : a), null);
+    const notes = [];
+    if (worst && worst.silhouette < 0.5) {
+      notes.push('<span class="warn">C' + worst.id + ' is the weakest band at silhouette ' +
+        fmt(worst.silhouette, 3) + ' \u2014 it is effectively touching its neighbour. Worth checking k.</span>');
+    }
+    const loose = R.stats.filter(s => s.n > 1 && s.density != null && s.density < 1);
+    if (loose.length) {
+      notes.push('<span class="warn">' + loose.map(s => 'C' + s.id).join(', ') +
+        (loose.length > 1 ? ' are ' : ' is ') + 'sparser than an even spread \u2014 mostly empty span ' +
+        'with a few points across it, which often means a hidden split.</span>');
+    }
+    if (!notes.length && widest) {
+      notes.push('Widest band is C' + widest.id + ' at ' + fmt(widest.width, sigDp()) +
+        '; raise k if you want it broken up.');
+    }
+    notes.push('<a href="#explainPanel" class="text-sky-400 hover:text-sky-300">What do these mean?</a>');
+    $('statsNote').innerHTML = notes.join(' ');
 
     $('copyStatsBtn').onclick = () => {
       const head = STAT_COLS.map(c => c.h).join('\t');

--- a/clustering/script.js
+++ b/clustering/script.js
@@ -98,6 +98,7 @@
     state.grid = []; state.table = null; state.profiles = []; state.result = null;
     state.valueCol = -1; state.labelCol = -1; state.pinned = null;
     $('structure').hidden = true; $('chartPanel').hidden = true; $('resultPanel').hidden = true;
+    $('statsPanel').hidden = true;
     $('pasteBox').style.minHeight = '';
     $('dataStatus').textContent = '';
   }
@@ -195,7 +196,9 @@
     const stats = API().clusterStats(values, res.assign, state.k);
     const ramp = API().rampFor(state.k);
 
-    state.result = { values, rowIx, res, stats, ramp, skipped: state.table.rows.length - values.length };
+    const overall = API().overallStats(values, stats);
+    state.result = { values, rowIx, res, stats, ramp, overall,
+      skipped: state.table.rows.length - values.length };
     $('kBadge').textContent = res.method === 'exact'
       ? '· exact optimum' : '· fast approximation, ' + values.length + ' values';
 
@@ -203,6 +206,7 @@
     paintChart();
     paintLegend();
     paintResults();
+    paintStats();
   }
 
   function paintElbow(values) {
@@ -384,6 +388,107 @@
     $('chart').querySelectorAll('circle.hi').forEach(c => c.classList.remove('hi'));
   }
 
+
+  // ------------------------------------------------------------- statistics
+
+  /* Columns are ordered so the eye runs from "how big" through "where" to "what shape",
+     and every derived one carries its definition in the header tooltip rather than in a
+     paragraph nobody reads. */
+  const STAT_COLS = [
+    { k: 'id', h: 'Cluster', t: 'Numbered low to high by value.' },
+    { k: 'n', h: 'n', num: true, t: 'Rows in this cluster.' },
+    { k: 'share', h: '% rows', num: true, t: 'Share of all clustered rows.' },
+    { k: 'min', h: 'min', num: true },
+    { k: 'max', h: 'max', num: true },
+    { k: 'mean', h: 'mean', num: true },
+    { k: 'median', h: 'median', num: true },
+    { k: 'sd', h: 'sd', num: true, t: 'Sample standard deviation within the cluster.' },
+    { k: 'width', h: 'width', num: true, t: 'max \u2212 min: how much of the value axis the cluster occupies.' },
+    { k: 'gapNext', h: 'gap \u2192', num: true, t: 'Distance from this cluster\u2019s max to the next cluster\u2019s min. A large gap means a clean break.' },
+    { k: 'density', h: 'density', num: true, t: 'Share of rows divided by share of the value axis. Dimensionless, so it does not care about units. 1,0 = exactly as dense as an even spread; 5,0 = five times denser; below 1,0 = sparser than even. Blank when the band has zero width.' },
+    { k: 'silhouette', h: 'silhouette', num: true, t: 'How much closer a point sits to its own cluster than to the nearest other one, averaged. 1 = perfectly separated, 0 = on the boundary, negative = probably in the wrong cluster. Singletons count as 0.' }
+  ];
+
+  function statCell(col, st) {
+    const v = st[col.k];
+    if (col.k === 'id') {
+      return '<span class="swatch" style="background:' + state.result.ramp[st.id - 1] + '"></span>C' + st.id;
+    }
+    if (v == null) return '<span class="muted">\u2014</span>';
+    if (col.k === 'n') return String(v);
+    if (col.k === 'share') return fmt(v * 100, 0) + ' %';
+    if (col.k === 'density') return fmt(v, 2) + '\u00d7';
+    if (col.k === 'silhouette') return fmt(v, 3);
+    return fmt(v, sigDp());
+  }
+
+  /** Decimal places that suit the spread of the data rather than a fixed guess. */
+  function sigDp() {
+    const w = state.result ? state.result.overall.width : 1;
+    if (!(w > 0)) return 2;
+    const mag = Math.floor(Math.log10(w));
+    return Math.min(6, Math.max(0, 2 - mag));
+  }
+
+  function paintStats() {
+    const R = state.result;
+    if (!R) { $('statsPanel').hidden = true; return; }
+    $('statsPanel').hidden = false;
+    const o = R.overall;
+
+    let html = '<tr>' + STAT_COLS.map(c =>
+      '<th class="' + (c.num ? 'n' : '') + '"' + (c.t ? ' title="' + esc(c.t) + '"' : '') + '>' +
+      esc(c.h) + '</th>').join('') + '</tr>';
+
+    R.stats.forEach(st => {
+      html += '<tr>' + STAT_COLS.map(c =>
+        '<td class="' + (c.num ? 'n' : '') + '">' + statCell(c, st) + '</td>').join('') + '</tr>';
+    });
+
+    const totals = {
+      id: null, n: o.n, share: 1, min: o.min, max: o.max, mean: o.mean,
+      median: o.median, sd: o.sd, width: o.width, gapNext: null,
+      density: null, silhouette: o.silhouette
+    };
+    html += '<tr class="total">' + STAT_COLS.map(c => {
+      if (c.k === 'id') return '<td>All</td>';
+      const st = totals;
+      if (st[c.k] == null) return '<td class="n"><span class="muted">\u2014</span></td>';
+      return '<td class="n">' + statCell(c, Object.assign({ id: 1 }, st)) + '</td>';
+    }).join('') + '</tr>';
+
+    $('statsTable').innerHTML = html;
+
+    $('statsSummary').innerHTML = o.explained != null
+      ? 'k = ' + state.k + ' accounts for <b>' + fmt(o.explained * 100, 1) +
+        ' %</b> of the total spread \u00b7 mean silhouette <b>' + fmt(o.silhouette, 3) + '</b>'
+      : '';
+
+    const worst = R.stats.filter(s => s.n > 0)
+      .reduce((a, b) => (a == null || b.silhouette < a.silhouette ? b : a), null);
+    $('statsNote').innerHTML =
+      '<b>density</b> is the cluster\u2019s share of the rows divided by its share of the value axis \u2014 ' +
+      'dimensionless, so it is unaffected by units. 1,0\u00d7 is exactly as dense as an even spread, ' +
+      'higher is tighter, lower is more strung out. <b>silhouette</b> runs from 1 (cleanly separated) ' +
+      'through 0 (sitting on the boundary) to negative (likely in the wrong cluster).' +
+      (worst && worst.silhouette < 0.5
+        ? ' <span class="warn">C' + worst.id + ' has the weakest separation at ' +
+          fmt(worst.silhouette, 3) + ' \u2014 worth checking whether k is right.</span>'
+        : '');
+
+    $('copyStatsBtn').onclick = () => {
+      const head = STAT_COLS.map(c => c.h).join('\t');
+      const body = R.stats.map(st => STAT_COLS.map(c => {
+        if (c.k === 'id') return 'C' + st.id;
+        const v = st[c.k];
+        if (v == null) return '';
+        if (c.k === 'share') return fmt(v * 100, 0);
+        return typeof v === 'number' ? fmt(v, c.k === 'n' ? 0 : 6) : String(v);
+      }).join('\t')).join('\n');
+      copyText(head + '\n' + body, $('copyStatsBtn'));
+    };
+  }
+
   // ------------------------------------------------------------------ output
 
   function outputRows() {
@@ -495,19 +600,7 @@
     });
     window.addEventListener('resize', () => { if (state.result) paintChart(); });
 
-    $('copyBtn').addEventListener('click', async () => {
-      const tsv = serialise('\t');
-      try {
-        await navigator.clipboard.writeText(tsv);
-        flash($('copyBtn'), 'Copied');
-      } catch (err) {
-        const ta = document.createElement('textarea');
-        ta.value = tsv; document.body.appendChild(ta); ta.select();
-        try { document.execCommand('copy'); flash($('copyBtn'), 'Copied'); }
-        catch (e2) { flash($('copyBtn'), 'Copy failed'); }
-        document.body.removeChild(ta);
-      }
-    });
+    $('copyBtn').addEventListener('click', () => copyText(serialise('\t'), $('copyBtn')));
 
     $('csvBtn').addEventListener('click', () => {
       const sep = state.decimal === ',' ? ';' : ',';
@@ -518,6 +611,19 @@
       document.body.appendChild(a); a.click(); document.body.removeChild(a);
       URL.revokeObjectURL(url);
     });
+  }
+
+  async function copyText(text, btn) {
+    try {
+      await navigator.clipboard.writeText(text);
+      flash(btn, 'Copied');
+    } catch (err) {
+      const ta = document.createElement('textarea');
+      ta.value = text; document.body.appendChild(ta); ta.select();
+      try { document.execCommand('copy'); flash(btn, 'Copied'); }
+      catch (e2) { flash(btn, 'Copy failed'); }
+      document.body.removeChild(ta);
+    }
   }
 
   function flash(btn, msg) {

--- a/clustering/test.js
+++ b/clustering/test.js
@@ -108,6 +108,38 @@ eq('elbow scan length', el.rows.length, 6);
 eq('wcss falls as k rises', el.rows.every((r, i) => i === 0 || r.wcss <= el.rows[i - 1].wcss + 1e-9), true);
 eq('elbow finds the three real groups', el.elbowK, 3);
 
+// ---- per-cluster statistics
+const sv = [0.16, 0.18, 0.21, 0.41, 0.42, 0.44, 0.45, 0.66, 0.68, 0.70, 0.71, 0.91, 0.93, 0.95, 0.97];
+const sr = A.clusterValues(sv, 4);
+const ss = A.clusterStats(sv, sr.assign, 4);
+eq('stats: one row per cluster', ss.length, 4);
+eq('stats: counts sum to n', ss.reduce((a, b) => a + b.n, 0), sv.length);
+eq('stats: shares sum to 1', Math.abs(ss.reduce((a, b) => a + b.share, 0) - 1) < 1e-12, true);
+near('stats: mean of the low band', ss[0].mean, (0.16 + 0.18 + 0.21) / 3, 1e-12);
+near('stats: median of a 4-point band', ss[1].median, (0.42 + 0.44) / 2, 1e-12);
+near('stats: width is max - min', ss[0].width, 0.21 - 0.16, 1e-12);
+near('stats: gap to the next cluster', ss[0].gapNext, 0.41 - 0.21, 1e-12);
+eq('stats: last cluster has no gap', ss[3].gapNext, null);
+eq('stats: sd of a singleton is 0', A.clusterStats([1, 5], [1, 2], 2)[0].sd, 0);
+eq('stats: zero-width band reports no density', A.clusterStats([1, 5], [1, 2], 2)[0].density, null);
+eq('stats: singleton silhouette is 0 by convention', A.clusterStats([1, 5], [1, 2], 2)[0].silhouette, 0);
+eq('stats: tight clusters are denser than an even spread', ss.every(x => x.density > 1), true);
+eq('stats: well separated data scores a high silhouette', ss.every(x => x.silhouette > 0.7), true);
+eq('stats: density is unit-free', (() => {
+  const scaled = sv.map(v => v * 1000);
+  const r2 = A.clusterValues(scaled, 4);
+  const s2 = A.clusterStats(scaled, r2.assign, 4);
+  return s2.every((x, i) => Math.abs(x.density - ss[i].density) < 1e-9);
+})(), true);
+
+const ov = A.overallStats(sv, ss);
+eq('overall: n', ov.n, sv.length);
+near('overall: width', ov.width, 0.97 - 0.16, 1e-12);
+eq('overall: clustering explains most of the spread', ov.explained > 0.98, true);
+eq('overall: silhouette is the n-weighted mean', Math.abs(ov.silhouette -
+  ss.reduce((a, x) => a + x.silhouette * x.n, 0) / sv.length) < 1e-12, true);
+eq('overall: empty input returns null', A.overallStats([], []), null);
+
 // ---- spectral ramp matches the validated values in SPEC.md 5.2
 eq('ramp k=3', A.rampFor(3), ['#7853d5', '#00cd89', '#e54e3f']);
 eq('ramp k=5', A.rampFor(5), ['#7853d5', '#00a0cc', '#00cd89', '#e7c100', '#e54e3f']);


### PR DESCRIPTION
One row per cluster below the results table, plus an **All** row. Branch is checked out in the working tree — reload `localhost:8080/structural_tools/clustering/` and press Load example.

| column | |
|---|---|
| n, % rows | size and share |
| min, max, mean, median, sd | the usual descriptives |
| width | `max − min` |
| gap → | this cluster's max to the next cluster's min — a large gap is a clean break |
| **density** | share of rows ÷ share of the value axis |
| **silhouette** | separation quality, [−1, 1] |

## The two derived numbers

**density is dimensionless on purpose.** Raw points-per-unit says nothing without knowing the units, and changes the instant the column is rescaled. A share-over-share ratio doesn't — there's a test that multiplies the data by 1000 and asserts the density is unchanged. `1,0×` is exactly as dense as an even spread across the same axis, higher is tighter, below `1,0×` is more strung out. Zero-width bands, which every singleton is, report `—` rather than dividing by zero.

**silhouette** is the standard measure: how much closer a point sits to its own cluster than to the nearest other one. Computed with prefix sums over the sorted groups so a mean absolute distance costs `O(log m)` rather than a scan — the whole table is `O(n·k·log n)`, not `O(n²)`. Singletons are 0 by convention.

## The All row earns its place

It carries **the share of total spread the clustering accounts for**, `1 − WCSS/TSS`. On the example at k = 4 that reads *99,5 %* — which is the number that actually tells you k is right. And when the weakest cluster drops below a silhouette of 0,5, the note names it and suggests checking k. On evenly-spread data at k = 3 that fires, with the summary reading *89,3 % · mean silhouette 0,445*.

## Details

- Decimal places follow the spread of the data rather than a fixed guess, so utilisations and kN both read sensibly
- **Copy stats (TSV)** button; the two copy buttons now share one clipboard helper with the `execCommand` fallback instead of duplicating it
- Colour swatches match the plot

## Verification

`node clustering/test.js` — **70 vectors, all pass** (19 new), including singletons, zero-width bands, k = 1, and the unit-rescaling invariance. Edge cases checked live: singletons give `—` density and 0 silhouette, k = 1 doesn't divide by zero, the weak-separation warning fires when it should. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
