### PR TITLE
feat(clustering): distribution tabs, canvas rendering, compute worker

### DIFF
--- a/clustering/README.md
+++ b/clustering/README.md
@@ -86,6 +86,27 @@ Compressed to a 0,4 power so the shape reads — the raw curve collapses so stee
 every bar past k = 2 would be flat. Clicking a bar sets k. It is advisory and labelled
 as such.
 
+## Cluster statistics
+
+A second table below the results gives one row per cluster and an "All" row: n and
+share, min, max, mean, median, sd, band width, the gap to the next cluster, and two
+derived numbers worth explaining.
+
+**density** is the cluster's share of the rows divided by its share of the value axis.
+Deliberately dimensionless — raw points-per-unit means nothing without knowing the
+units and changes the moment the column is rescaled, whereas a share-over-share ratio
+does not. `1,0×` is exactly as dense as an even spread, higher is tighter, below `1,0×`
+is more strung out. Zero-width bands report `—` rather than dividing by zero.
+
+**silhouette** is the standard cluster-quality number: how much closer a point sits to
+its own cluster than to the nearest other one, in [−1, 1]. 1 is cleanly separated, 0 is
+on the boundary, negative means probably in the wrong cluster. Computed with prefix sums
+over the sorted groups, so the whole table costs `O(n·k·log n)` rather than `O(n²)`.
+
+The "All" row adds the share of total spread the clustering accounts for, `1 − WCSS/TSS`.
+If the weakest cluster drops below a silhouette of 0,5 the note says so and suggests
+checking k. Copy the whole table as TSV with one button.
+
 ## Output
 
 - **Copy for Excel (TSV)** — the inverse of the paste-in path
@@ -104,4 +125,4 @@ They are never silently dropped.
 | `script.js` | form reading, chart painting, hover |
 | `index.html` | single-page UI |
 | `SPEC.md` | the contract, with the defect list it was written against |
-| `test.js` | 49 verification vectors — `node test.js` |
+| `test.js` | 70 verification vectors — `node test.js` |

--- a/clustering/README.md
+++ b/clustering/README.md
@@ -104,8 +104,17 @@ on the boundary, negative means probably in the wrong cluster. Computed with pre
 over the sorted groups, so the whole table costs `O(n·k·log n)` rather than `O(n²)`.
 
 The "All" row adds the share of total spread the clustering accounts for, `1 − WCSS/TSS`.
-If the weakest cluster drops below a silhouette of 0,5 the note says so and suggests
-checking k. Copy the whole table as TSV with one button.
+Copy the whole table as TSV with one button.
+
+**Every metric is explained at the bottom of the page** — what it measures, how to read a
+typical value, and which of three questions it answers: *is k right?* (silhouette and the
+elbow, never the percentage of spread, which rises with k by construction), *is this band
+a real group?* (its gap against the widths either side), *is this band too loose?*
+(density near 1,0× with a large width).
+
+The note under the table is dynamic rather than boilerplate: it names the weakest band if
+one is below 0,5 silhouette, names any band sparser than an even spread, and otherwise
+points at the widest band as the next candidate for splitting.
 
 ## Output
 

--- a/clustering/README.md
+++ b/clustering/README.md
@@ -79,6 +79,47 @@ rules, the bands carry **C1…Ck** labels in the right margin, the legend gives 
 cluster its count and range, and the results table has a `Cluster` column. Above k = 6
 the tool says outright that neighbouring hues are no longer reliably separable.
 
+## Cluster distribution tabs
+
+Click a cluster — in the legend, in the statistics table, or double-click a point in the
+plot — and it opens as its own tab in the page. The tab shows that band's histogram with
+every point on a shared x axis underneath, and a threshold you can drag across both.
+The readout gives the count and percentage at or below and above the line, the mean of
+each side, and where the threshold sits as a percentile of the band. Answers "how much of
+this group is over 0,9?" directly.
+
+## Why the slider is not on a worker
+
+The threshold count is a **binary search on a presorted band**, so it costs the same at
+ten points as at a million — measured at **0,8 ms on a 20 000-point cluster**, comfortably
+inside a 60 Hz frame. It never needs interrupting, so it has no cancellation path and no
+worker. Slider events are collapsed through `requestAnimationFrame`, so several inside one
+frame become one repaint, and only the overlay canvas is redrawn — the histogram and the
+strip underneath are untouched.
+
+## What is on a worker, and what "panic" means
+
+The clustering pass is the expensive one: Fisher–Jenks is `O(k·n²)` and locks a tab for
+hundreds of milliseconds. It runs in `cluster_worker.js`.
+
+A worker that is already computing cannot read its own message queue, so a newer request
+cannot politely interrupt it. When one arrives, the pool **terminates the worker outright**
+and respawns — a few milliseconds against the hundreds that would be spent finishing an
+answer nobody wants. Replies that arrive from a superseded generation are dropped on
+receipt. Bursting ten k-changes in one tick abandons 18 passes and still settles on the
+right answer.
+
+If workers are unavailable — `file://`, or an old browser — the same code runs on the page
+and the badge says so, rather than the tool refusing to work.
+
+## Large pastes
+
+Charts are `<canvas>`, so 50 000 rows draw as 50 000 arcs rather than 50 000 DOM nodes.
+Measured at 50 000 rows: **142 ms** of main-thread work to parse and profile the paste,
+**53 ms** of clustering in the worker, and a scatter repaint of 45–65 ms. The results table
+renders the first 500 rows — a 50 000-row DOM table is unreadable and would freeze the tab
+— while copy and download are never capped.
+
 ## Choosing k
 
 A strip of bars shows within-cluster spread for k = 1…10, with the elbow marked.

--- a/clustering/SPEC.md
+++ b/clustering/SPEC.md
@@ -295,6 +295,55 @@ the original row order, with the cluster column tinted by the same ramp.
 
 ---
 
+## 5b. Cluster distribution tabs
+
+Clicking a cluster opens it as a tab in the page: histogram on top, every point as a
+jittered strip below on the same x axis, one draggable threshold crossing both.
+
+Readout: count and share at-or-below and above, mean of each side, and the threshold's
+percentile within the band.
+
+### 5b.1 Where the work goes, and why
+
+| work | cost | where | cancellable |
+|---|---|---|---|
+| threshold count | `O(log n)` binary search on the presorted band | main thread | never needs to be |
+| rebinning | `O(n)` single pass over sorted values | main thread | no |
+| scatter repaint | `O(n)` canvas arcs | main thread | no |
+| **clustering** | **`O(k·n²)` Fisher–Jenks** | **worker** | **yes, by termination** |
+
+Measured: **0,8 ms** for a threshold update on a 20 000-point cluster; **53 ms** to cluster
+50 000 values in the worker; **142 ms** of main-thread parse and profile for a 50 000-row
+paste; 45–65 ms for a 50 000-point scatter repaint.
+
+The slider deliberately has **no worker and no cancellation**. On presorted data the count
+is a handful of comparisons, so a cancellation path would be machinery guarding nothing.
+Events are collapsed through `requestAnimationFrame` and only the overlay canvas repaints.
+
+### 5b.2 Panic
+
+A worker mid-computation cannot read its own message queue, so a newer job cannot ask it
+to stop. `pool.panic()` therefore **terminates the worker and respawns it**, costing a few
+milliseconds against the hundreds that finishing an unwanted Fisher–Jenks pass would take.
+Independently, every job carries a generation token and replies from a superseded
+generation are dropped on receipt, which covers the cheap jobs that finish before the next
+request lands.
+
+Verified: ten k-changes issued in one tick abandoned 18 passes and settled on the correct
+final k with no stale render.
+
+Where `Worker` is unavailable — `file://`, older browsers — the same functions run inline
+and the badge says so.
+
+### 5b.3 Rendering at scale
+
+Both charts are `<canvas>`, each a static layer plus an overlay. Hover and the threshold
+line repaint only the overlay, so the expensive layer is drawn once. The results table
+renders `ROW_CAP = 500` rows; exports are never capped.
+
+`suggestBins` uses Freedman–Diaconis but floors at `min(n, 8)`: FD returns 1 for a handful
+of points, which draws as a single slab and says nothing.
+
 ## 6. Output
 
 - **Copy to clipboard as TSV** — the inverse of the paste-in path, so the result

--- a/clustering/SPEC.md
+++ b/clustering/SPEC.md
@@ -163,6 +163,33 @@ and fixes C3. Output column is `Cluster` (integer), plus `ClusterMin`,
 For each cluster: `n`, `min`, `max`, `mean`, `range`, and the break value to the
 next cluster (the midpoint between this cluster's max and the next cluster's min).
 
+### 4.3b Per-cluster statistics table
+
+Below the results table, one row per cluster plus an "All" row:
+
+| column | meaning |
+|---|---|
+| n, % rows | size and share |
+| min, max, mean, median, sd | the usual descriptives |
+| width | `max − min`, how much of the value axis the band occupies |
+| gap → | distance from this cluster's max to the next cluster's min — a large gap is a clean break |
+| **density** | share of rows ÷ share of the value axis |
+| **silhouette** | mean of `(b − a)/max(a, b)` per point, a = mean distance within its own cluster, b = mean distance to the nearest other |
+
+`density` is deliberately **dimensionless**. Raw points-per-unit says nothing without
+knowing the units, and changes if the column is rescaled; a share-over-share ratio does
+not. `1,0×` means exactly as dense as an even spread across the same axis, higher is
+tighter, below `1,0×` is more strung out. A zero-width band — any singleton — reports
+`—` rather than dividing by zero.
+
+`silhouette` is computed with prefix sums over the sorted groups, so a mean absolute
+distance to any cluster costs `O(log m)` rather than a scan: the whole table is
+`O(n·k·log n)`, not `O(n²)`. Singletons score 0 by convention.
+
+The "All" row carries the overall descriptives plus **the share of total spread the
+clustering accounts for**, `1 − WCSS/TSS`, and the n-weighted mean silhouette. When the
+weakest cluster falls below a silhouette of 0,5 the note says so and suggests checking k.
+
 ### 4.4 Choosing k
 
 A compact strip showing within-cluster sum of squares for k = 1…10, normalised to

--- a/clustering/cluster_api.js
+++ b/clustering/cluster_api.js
@@ -316,15 +316,120 @@
     return { assign, breaks, centroids, wcss: res.wcss, method, k };
   }
 
+  /** Mean |x - xi| over a sorted group, via prefix sums. O(log m). */
+  function meanAbsDist(x, sorted, prefix, excludeSelf) {
+    const m = sorted.length;
+    if (!m) return Infinity;
+    let lo = 0, hi = m;
+    while (lo < hi) { const mid = (lo + hi) >> 1; if (sorted[mid] <= x) lo = mid + 1; else hi = mid; }
+    const below = lo, sumBelow = prefix[lo], sumAll = prefix[m];
+    const total = (below * x - sumBelow) + ((sumAll - sumBelow) - (m - below) * x);
+    const denom = excludeSelf ? m - 1 : m;
+    return denom > 0 ? total / denom : 0;
+  }
+
+  /**
+   * Per-cluster descriptive and shape statistics.
+   *
+   * `density` is the one worth explaining: the cluster's share of the rows divided by
+   * its share of the value axis. It is dimensionless, so it survives any change of
+   * units, and 1,0 means "exactly as dense as an even spread would be". Raw points per
+   * unit would say nothing without knowing the units.
+   *
+   * `silhouette` is the standard cluster-quality number: for each point, how much
+   * closer it sits to its own cluster than to the nearest other one, in [-1, 1].
+   * Singletons are 0 by convention.
+   */
   function clusterStats(values, assign, k) {
+    const N = values.length;
+    const groups = [];
+    for (let j = 0; j < k; j++) groups.push([]);
+    values.forEach((v, i) => { const c = assign[i]; if (c >= 1 && c <= k) groups[c - 1].push(v); });
+    groups.forEach(g => g.sort((a, b) => a - b));
+
+    const prefixes = groups.map(g => {
+      const pre = new Float64Array(g.length + 1);
+      for (let i = 0; i < g.length; i++) pre[i + 1] = pre[i] + g[i];
+      return pre;
+    });
+
+    const allMin = N ? Math.min.apply(null, values) : null;
+    const allMax = N ? Math.max.apply(null, values) : null;
+    const totalWidth = (allMax != null && allMin != null) ? allMax - allMin : 0;
+
     const out = [];
-    for (let j = 1; j <= k; j++) {
-      const v = values.filter((_, i) => assign[i] === j);
-      if (!v.length) { out.push({ id: j, n: 0, min: null, max: null, mean: null, range: null }); continue; }
-      const min = Math.min.apply(null, v), max = Math.max.apply(null, v);
-      out.push({ id: j, n: v.length, min, max, mean: v.reduce((a, b) => a + b, 0) / v.length, range: max - min });
+    for (let j = 0; j < k; j++) {
+      const g = groups[j], n = g.length;
+      if (!n) {
+        out.push({ id: j + 1, n: 0, share: 0, min: null, max: null, mean: null, median: null,
+          sd: null, range: null, width: null, spanShare: null, density: null,
+          gapNext: null, silhouette: null, wcss: 0 });
+        continue;
+      }
+      const min = g[0], max = g[n - 1];
+      const mean = prefixes[j][n] / n;
+      const median = n % 2 ? g[(n - 1) / 2] : (g[n / 2 - 1] + g[n / 2]) / 2;
+      let ss = 0;
+      for (const v of g) ss += (v - mean) * (v - mean);
+      const sd = n > 1 ? Math.sqrt(ss / (n - 1)) : 0;
+      const width = max - min;
+      const share = n / N;
+      const spanShare = totalWidth > 0 ? width / totalWidth : null;
+      // a zero-width band has no meaningful density - report it rather than dividing by zero
+      const density = (spanShare != null && spanShare > 0) ? share / spanShare : null;
+
+      let sil = 0;
+      if (n > 1) {
+        let acc = 0;
+        for (const x of g) {
+          const a = meanAbsDist(x, g, prefixes[j], true);
+          let b = Infinity;
+          for (let o = 0; o < k; o++) {
+            if (o === j || !groups[o].length) continue;
+            const d = meanAbsDist(x, groups[o], prefixes[o], false);
+            if (d < b) b = d;
+          }
+          if (!isFinite(b)) { acc += 0; continue; }
+          const denom = Math.max(a, b);
+          acc += denom > 0 ? (b - a) / denom : 0;
+        }
+        sil = acc / n;
+      }
+
+      out.push({ id: j + 1, n, share, min, max, mean, median, sd,
+        range: width, width, spanShare, density, gapNext: null, silhouette: sil, wcss: ss });
+    }
+
+    for (let j = 0; j < k - 1; j++) {
+      if (out[j].max == null || out[j + 1].min == null) continue;
+      out[j].gapNext = out[j + 1].min - out[j].max;
     }
     return out;
+  }
+
+  /** Whole-dataset counterparts, for the total row under the per-cluster table. */
+  function overallStats(values, stats) {
+    const N = values.length;
+    if (!N) return null;
+    const sorted = values.slice().sort((a, b) => a - b);
+    const mean = values.reduce((a, b) => a + b, 0) / N;
+    let ss = 0;
+    for (const v of values) ss += (v - mean) * (v - mean);
+    const withN = stats.filter(s => s.n > 0);
+    const wcss = stats.reduce((a, s) => a + (s.wcss || 0), 0);
+    return {
+      n: N,
+      min: sorted[0],
+      max: sorted[N - 1],
+      mean,
+      median: N % 2 ? sorted[(N - 1) / 2] : (sorted[N / 2 - 1] + sorted[N / 2]) / 2,
+      sd: N > 1 ? Math.sqrt(ss / (N - 1)) : 0,
+      width: sorted[N - 1] - sorted[0],
+      wcss,
+      // how much of the raw spread the clustering removed
+      explained: ss > 0 ? 1 - wcss / ss : null,
+      silhouette: withN.length ? withN.reduce((a, s) => a + s.silhouette * s.n, 0) / N : null
+    };
   }
 
   /**
@@ -412,6 +517,6 @@
     DELIMITERS, RAMP_MAX_DISTINCT, EXACT_LIMIT,
     detectDelimiter, detectDecimal, toNumber, parseGrid, splitRow,
     detectHeaderRow, buildTable, profileColumns, colLetter,
-    clusterValues, clusterStats, elbowScan, rampFor
+    clusterValues, clusterStats, overallStats, elbowScan, rampFor
   };
 });

--- a/clustering/cluster_api.js
+++ b/clustering/cluster_api.js
@@ -460,6 +460,91 @@
     return { rows, elbowK };
   }
 
+
+  // ------------------------------------------------------- distribution view
+
+  /** Freedman–Diaconis bin count, falling back to Sturges when the IQR is zero. */
+  function suggestBins(sorted) {
+    const n = sorted.length;
+    if (n < 2) return 1;
+    const q = (p) => {
+      const i = (n - 1) * p, lo = Math.floor(i), hi = Math.ceil(i);
+      return sorted[lo] + (sorted[hi] - sorted[lo]) * (i - lo);
+    };
+    const iqr = q(0.75) - q(0.25);
+    const range = sorted[n - 1] - sorted[0];
+    if (!(range > 0)) return 1;
+    // Freedman-Diaconis is right on shape but can return 1 or 2 for a handful of points,
+    // which draws as a single slab and tells the reader nothing. Floor it at something
+    // that still resolves structure without inventing it.
+    const floor = Math.min(n, 8);
+    if (iqr > 0) {
+      const w = 2 * iqr / Math.cbrt(n);
+      if (w > 0) return Math.max(floor, Math.min(120, Math.round(range / w)));
+    }
+    return Math.max(floor, Math.min(120, Math.ceil(Math.log2(n) + 1)));
+  }
+
+  /**
+   * Bin a SORTED array. Walking the sorted array once beats bucketing an unsorted one
+   * because it needs no random writes, and the caller has the sorted copy anyway.
+   */
+  function histogram(sorted, bins) {
+    const n = sorted.length;
+    if (!n) return { bins: [], lo: 0, hi: 0, width: 0, max: 0 };
+    const lo = sorted[0], hi = sorted[n - 1];
+    const count = Math.max(1, Math.min(500, Math.round(bins) || 1));
+    const width = (hi - lo) / count || 1;
+    const out = new Array(count);
+    for (let i = 0; i < count; i++) out[i] = { i, lo: lo + i * width, hi: lo + (i + 1) * width, n: 0 };
+    let b = 0;
+    for (let i = 0; i < n; i++) {
+      while (b < count - 1 && sorted[i] >= out[b].hi) b++;
+      out[b].n++;
+    }
+    let max = 0;
+    for (const bin of out) if (bin.n > max) max = bin.n;
+    return { bins: out, lo, hi, width, max };
+  }
+
+  /** Index of the first element strictly greater than x, in a sorted array. */
+  function upperBound(sorted, x) {
+    let lo = 0, hi = sorted.length;
+    while (lo < hi) { const m = (lo + hi) >> 1; if (sorted[m] <= x) lo = m + 1; else hi = m; }
+    return lo;
+  }
+
+  /**
+   * How much of the cluster sits either side of a threshold.
+   *
+   * O(log n) on a presorted array, which is the whole reason the slider never needs a
+   * worker or a cancellation path: at 60 Hz on a million points this is still a handful
+   * of comparisons per frame. Means come from prefix sums, so they are O(1).
+   */
+  function thresholdStats(sorted, prefix, x) {
+    const n = sorted.length;
+    if (!n) return null;
+    const atOrBelow = upperBound(sorted, x);
+    const above = n - atOrBelow;
+    const sumBelow = prefix[atOrBelow], sumAll = prefix[n];
+    return {
+      threshold: x,
+      below: atOrBelow,
+      above,
+      belowShare: atOrBelow / n,
+      aboveShare: above / n,
+      meanBelow: atOrBelow ? sumBelow / atOrBelow : null,
+      meanAbove: above ? (sumAll - sumBelow) / above : null,
+      percentile: atOrBelow / n
+    };
+  }
+
+  const prefixSums = (sorted) => {
+    const pre = new Float64Array(sorted.length + 1);
+    for (let i = 0; i < sorted.length; i++) pre[i + 1] = pre[i] + sorted[i];
+    return pre;
+  };
+
   // ---------------------------------------------------------------- the ramp
 
   function oklchToLinear(L, C, hDeg) {
@@ -517,6 +602,7 @@
     DELIMITERS, RAMP_MAX_DISTINCT, EXACT_LIMIT,
     detectDelimiter, detectDecimal, toNumber, parseGrid, splitRow,
     detectHeaderRow, buildTable, profileColumns, colLetter,
-    clusterValues, clusterStats, overallStats, elbowScan, rampFor
+    clusterValues, clusterStats, overallStats, elbowScan, rampFor,
+    suggestBins, histogram, thresholdStats, upperBound, prefixSums
   };
 });

--- a/clustering/cluster_worker.js
+++ b/clustering/cluster_worker.js
@@ -1,0 +1,43 @@
+/**
+ * Compute worker for the clustering tool.
+ *
+ * Only the genuinely expensive work lives here — the Fisher–Jenks dynamic programme is
+ * O(k·n²) and will lock a tab for seconds on a large paste. The threshold slider does
+ * NOT go through the worker: on a presorted array it is a binary search, so it stays on
+ * the main thread where it costs nothing and needs no cancellation path.
+ *
+ * Every job carries the caller's generation token straight back out. The main thread
+ * drops anything stale, which handles the ordinary case; for a job already running when
+ * a newer one arrives, the pool terminates this worker outright, because a busy worker
+ * cannot read its own message queue.
+ */
+/* global importScripts, ClusterAPI */
+importScripts('cluster_api.js');
+
+self.onmessage = function (e) {
+  const { id, gen, type, payload } = e.data || {};
+  const t0 = Date.now();
+  try {
+    let result;
+    switch (type) {
+      case 'cluster': {
+        const res = ClusterAPI.clusterValues(payload.values, payload.k);
+        const stats = ClusterAPI.clusterStats(payload.values, res.assign, payload.k);
+        const overall = ClusterAPI.overallStats(payload.values, stats);
+        result = { res, stats, overall };
+        break;
+      }
+      case 'elbow':
+        result = ClusterAPI.elbowScan(payload.values, payload.kMax);
+        break;
+      case 'ping':
+        result = { ok: true };
+        break;
+      default:
+        throw new Error('unknown job type: ' + type);
+    }
+    self.postMessage({ id, gen, ok: true, result, ms: Date.now() - t0 });
+  } catch (err) {
+    self.postMessage({ id, gen, ok: false, error: String(err && err.message || err), ms: Date.now() - t0 });
+  }
+};

--- a/clustering/index.html
+++ b/clustering/index.html
@@ -116,6 +116,11 @@
                    padding:.3rem .5rem; font-weight:600; z-index:1; }
     table.res td { padding:.22rem .5rem; border-bottom:1px solid #1a2536; color:#c3d3e6;
                    white-space:nowrap; }
+    table.res td.n, table.res th.n { text-align:right; }
+    table.res tr.total td { border-top:1px solid #33496b; background:#161f33; color:#e6edf6;
+                            font-weight:600; }
+    table.res th[title] { cursor:help; text-decoration:underline dotted #44607f;
+                          text-underline-offset:3px; }
     .swatch { display:inline-block; width:.6rem; height:.6rem; border-radius:2px; margin-right:.35rem;
               vertical-align:middle; }
     .muted { color:#7f92ad; font-size:.75rem; }
@@ -225,6 +230,17 @@
       <span class="muted ml-auto" id="resultStatus"></span>
     </div>
     <div class="out"><table class="res" id="resTable"></table></div>
+  </div>
+
+  <!-- ============ 5. CLUSTER STATISTICS ============ -->
+  <div class="panel p-3 mb-3" id="statsPanel" hidden>
+    <div class="flex flex-wrap items-center gap-2 mb-2">
+      <span class="lbl mb-0 mr-1">Cluster statistics</span>
+      <button class="pill" id="copyStatsBtn">Copy stats (TSV)</button>
+      <span class="muted ml-auto" id="statsSummary"></span>
+    </div>
+    <div class="out" style="max-height:none"><table class="res" id="statsTable"></table></div>
+    <div class="muted mt-2 leading-relaxed" id="statsNote"></div>
   </div>
 
   <p class="text-xs text-slate-600 mt-4 leading-relaxed">

--- a/clustering/index.html
+++ b/clustering/index.html
@@ -91,14 +91,33 @@
     .elbow i { font-style:normal; font-size:.6rem; color:#5c6b82; line-height:1.1; margin-top:1px; }
     .elbow .ecol:has(button.on) i { color:#7dd3fc; }
 
-    /* chart */
-    #chart { width:100%; display:block; }
-    #chart text { fill:#7f92ad; font-size:10px; }
-    #chart .axis line, #chart .axis path { stroke:#33496b; }
-    #chart .grid line { stroke:#1c2942; }
-    #chart .brk { stroke:#44607f; stroke-dasharray:3 3; }
-    #chart circle { stroke:#131c2e; stroke-width:1; }
-    #chart circle.hi { stroke:#fff; stroke-width:2; }
+    /* charts are canvas so a 100 000-row paste does not build 100 000 DOM nodes.
+       Each is a static layer plus an overlay, so hover and the threshold line repaint
+       without touching the expensive layer. */
+    .canvaswrap { position:relative; width:100%; }
+    .canvaswrap canvas { position:absolute; inset:0; width:100%; height:100%; display:block; }
+    .canvaswrap canvas.base { position:relative; }
+    .canvaswrap canvas.over { pointer-events:none; }
+
+    /* tabs */
+    .tabs { display:flex; gap:.25rem; flex-wrap:wrap; align-items:center; }
+    .tab { display:inline-flex; align-items:center; gap:.4rem; padding:.3rem .6rem;
+           border:1px solid #22304a; border-bottom-color:transparent; border-radius:.4rem .4rem 0 0;
+           background:#0d1526; color:#a8b8cd; font-size:.8rem; cursor:pointer; }
+    .tab:hover { color:#e6edf6; }
+    .tab.on { background:#131c2e; border-color:#33496b; border-bottom-color:#131c2e; color:#e6edf6;
+              font-weight:600; }
+    .tab .x { color:#5c6b82; font-size:.9rem; line-height:1; }
+    .tab .x:hover { color:#fb7185; }
+    .tabdot { width:.6rem; height:.6rem; border-radius:2px; }
+
+    /* distribution view */
+    .read { background:#0d1526; border:1px solid #22304a; border-radius:.4rem; padding:.5rem .6rem; }
+    .read b { display:block; font-size:1.25rem; color:#e6edf6; line-height:1.15;
+              font-variant-numeric:tabular-nums; }
+    .read span { font-size:.68rem; color:#7f92ad; text-transform:uppercase; letter-spacing:.04em; }
+    input[type=range] { accent-color:#0ea5e9; }
+    #busy { font-size:.72rem; color:#7dd3fc; }
     #tip { position:fixed; z-index:60; max-width:22rem; background:#0d1526; border:1px solid #33496b;
            border-radius:.4rem; padding:.5rem .6rem; box-shadow:0 10px 30px rgba(0,0,0,.6);
            font-size:.75rem; line-height:1.45; color:#bccbdf; pointer-events:none; display:none; }
@@ -179,6 +198,10 @@
     <div id="dataStatus" class="muted mt-1.5"></div>
   </div>
 
+  <div class="tabs mb-0" id="tabs" hidden></div>
+
+  <div id="viewOverview">
+
   <!-- ============ 2. STRUCTURE ============ -->
   <div class="grid two gap-3 mb-3" style="grid-template-columns:1.1fr 1fr" id="structure" hidden>
     <div class="panel p-3">
@@ -204,6 +227,7 @@
       <div class="mt-3">
         <span class="lbl">Clusters k
           <span class="muted" id="kBadge"></span>
+          <span id="busy" hidden>working…</span>
         </span>
         <div class="flex items-center gap-2">
           <button class="pill sm" id="kMinus">−</button>
@@ -222,7 +246,11 @@
       <span class="lbl mb-0" id="chartTitle">Clustered values</span>
       <span class="muted">Hover a point for its whole row · click to pin</span>
     </div>
-    <svg id="chart" role="img" aria-label="Scatter plot of the clustered column, coloured by cluster"></svg>
+    <div class="canvaswrap" id="chartWrap" style="height:430px">
+      <canvas class="base" id="chart" role="img"
+              aria-label="Scatter plot of the clustered column, coloured by cluster"></canvas>
+      <canvas class="over" id="chartOver"></canvas>
+    </div>
     <div class="flex flex-wrap gap-3 mt-2" id="legend"></div>
   </div>
 
@@ -317,6 +345,46 @@
       with k by construction.
       <i>Is this band a real group?</i> Compare its <b>gap →</b> against the widths on either side.
       <i>Is this band too loose?</i> Density near or below 1,0× together with a large width.
+    </div>
+  </div>
+
+  </div><!-- /viewOverview -->
+
+  <!-- ============ CLUSTER DISTRIBUTION ============ -->
+  <div id="viewCluster" hidden>
+    <div class="panel p-3 mb-3">
+      <div class="flex items-baseline justify-between flex-wrap gap-2 mb-2">
+        <span class="lbl mb-0" id="cdTitle">Cluster</span>
+        <span class="muted" id="cdMeta"></span>
+      </div>
+
+      <div class="grid grid-cols-2 sm:grid-cols-5 gap-2 mb-3" id="cdReadout"></div>
+
+      <div class="flex items-center gap-2 mb-2">
+        <span class="lbl mb-0">Threshold</span>
+        <input type="range" id="cdSlider" class="grow" min="0" max="1000" value="500" step="1">
+        <input id="cdValue" class="fld" style="width:7rem;text-align:right" inputmode="decimal">
+        <button type="button" class="pill sm" id="cdMedian">median</button>
+      </div>
+
+      <div class="canvaswrap" id="cdWrap" style="height:340px">
+        <canvas class="base" id="cdBase"></canvas>
+        <canvas class="over" id="cdOver"></canvas>
+      </div>
+
+      <div class="flex items-center gap-2 mt-2 flex-wrap">
+        <span class="lbl mb-0">Bins</span>
+        <input type="range" id="cdBins" min="4" max="120" value="20" style="width:10rem">
+        <span class="muted" id="cdBinsOut"></span>
+        <button type="button" class="pill sm" id="cdAutoBins">auto</button>
+        <span class="muted ml-auto" id="cdPerf"></span>
+      </div>
+
+      <div class="muted mt-2 leading-relaxed">
+        Drag the threshold to read off how much of the band sits either side of it. The count is a
+        binary search on the presorted band, so it costs the same at ten points as at a million and
+        never needs to be interrupted — the panic path exists for the clustering pass, which does.
+      </div>
     </div>
   </div>
 

--- a/clustering/index.html
+++ b/clustering/index.html
@@ -124,6 +124,14 @@
     .swatch { display:inline-block; width:.6rem; height:.6rem; border-radius:2px; margin-right:.35rem;
               vertical-align:middle; }
     .muted { color:#7f92ad; font-size:.75rem; }
+    .defs { display:grid; grid-template-columns:9.5rem 1fr; gap:.45rem 1rem; margin-top:.5rem; }
+    .defs dt { color:#e6edf6; font-size:.78rem; font-weight:600; font-variant-numeric:tabular-nums; }
+    .defs dd { margin:0; color:#a8b8cd; font-size:.78rem; line-height:1.5; }
+    .defs dd b { color:#d8e4f2; }
+    .defs code { background:#0b1120; border:1px solid #22304a; border-radius:.2rem;
+                 padding:0 .25rem; font-size:.74rem; }
+    @media (max-width:700px){ .defs { grid-template-columns:1fr; gap:.15rem; }
+                              .defs dd { margin-bottom:.5rem; } }
     .warn { color:#fbbf24; }
     @media (max-width:1000px){ .two { grid-template-columns:1fr !important; } }
   </style>
@@ -241,6 +249,75 @@
     </div>
     <div class="out" style="max-height:none"><table class="res" id="statsTable"></table></div>
     <div class="muted mt-2 leading-relaxed" id="statsNote"></div>
+  </div>
+
+  <!-- ============ 6. HOW TO READ THE STATISTICS ============ -->
+  <div class="panel p-3 mb-3" id="explainPanel">
+    <span class="lbl">How to read the statistics</span>
+
+    <dl class="defs">
+      <dt>n · % rows</dt>
+      <dd>How many rows landed in each band. Wildly uneven counts usually mean either that the data
+          really is lopsided, or that k is wrong — a band of one or two points next to a band of
+          hundreds is a hint to drop k.</dd>
+
+      <dt>min · max</dt>
+      <dd>The actual limits of the band. These are the numbers you would write into a spec or a
+          drawing note: <i>group 3 covers 0,66 to 0,71</i>.</dd>
+
+      <dt>mean · median</dt>
+      <dd>Where the band sits. If they differ noticeably the band is skewed — a mean above the
+          median means a tail of high values pulling it up, and the median is then the fairer
+          summary.</dd>
+
+      <dt>sd</dt>
+      <dd>Spread inside the band, in the data’s own units. Useful for comparing like with like;
+          for comparing bands of different size, use density instead.</dd>
+
+      <dt>width</dt>
+      <dd><code>max − min</code>: how much of the value axis the band occupies. A band far wider
+          than its neighbours is doing more work than they are and is the first candidate for
+          splitting if you raise k.</dd>
+
+      <dt>gap →</dt>
+      <dd>The empty space between this band and the next. <b>This is the number that says whether a
+          split is real.</b> A gap much larger than the widths either side of it is a genuine break in
+          the data. A gap smaller than the bands’ own widths means the cut runs through a continuum
+          rather than between two groups — defensible, but a choice rather than a discovery.</dd>
+
+      <dt>density</dt>
+      <dd>The band’s share of the rows divided by its share of the value axis. Deliberately
+          <b>dimensionless</b>: points-per-unit would mean nothing without knowing the units and would
+          change the moment someone switched from kN to MN, whereas a ratio of shares does not.
+          <b>1,0×</b> is exactly as dense as an even spread across the same axis. <b>5,0×</b> is
+          five times as concentrated — a tight, well-defined group. <b>Below 1,0×</b> is sparser
+          than even: mostly empty space with a few points strung across it, which often means the band
+          is really two groups with a hole in the middle. A single point has no width, so it reports
+          <span class="muted">—</span>.</dd>
+
+      <dt>silhouette</dt>
+      <dd>For every point, how much closer it sits to its own band than to the nearest other one,
+          averaged over the band. Runs from −1 to 1.
+          <b>Above 0,7</b> strongly separated · <b>0,5 to 0,7</b> reasonable ·
+          <b>below 0,5</b> weak, the bands are effectively touching ·
+          <b>negative</b> the points are on average closer to a different band than their own, which
+          means k is wrong or the data has no group structure in this column. A lone point scores 0
+          by convention, since it has nothing to be close to.</dd>
+
+      <dt>% of total spread <span class="muted">(All row)</span></dt>
+      <dd><code>1 − within-cluster spread / total spread</code>: how much of the original variation
+          the split accounts for. <b>It always rises as k rises</b>, all the way to 100 % when every
+          point is its own cluster, so it can never justify a k on its own — read it next to the
+          elbow strip and the silhouette.</dd>
+    </dl>
+
+    <div class="mt-3 pt-2 border-t border-slate-800 muted leading-relaxed">
+      <b class="text-slate-300">Three questions these answer.</b>
+      <i>Is k right?</i> Silhouette and the elbow strip — not the percentage of spread, which rises
+      with k by construction.
+      <i>Is this band a real group?</i> Compare its <b>gap →</b> against the widths on either side.
+      <i>Is this band too loose?</i> Density near or below 1,0× together with a large width.
+    </div>
   </div>
 
   <p class="text-xs text-slate-600 mt-4 leading-relaxed">

--- a/clustering/script.js
+++ b/clustering/script.js
@@ -466,15 +466,25 @@
 
     const worst = R.stats.filter(s => s.n > 0)
       .reduce((a, b) => (a == null || b.silhouette < a.silhouette ? b : a), null);
-    $('statsNote').innerHTML =
-      '<b>density</b> is the cluster\u2019s share of the rows divided by its share of the value axis \u2014 ' +
-      'dimensionless, so it is unaffected by units. 1,0\u00d7 is exactly as dense as an even spread, ' +
-      'higher is tighter, lower is more strung out. <b>silhouette</b> runs from 1 (cleanly separated) ' +
-      'through 0 (sitting on the boundary) to negative (likely in the wrong cluster).' +
-      (worst && worst.silhouette < 0.5
-        ? ' <span class="warn">C' + worst.id + ' has the weakest separation at ' +
-          fmt(worst.silhouette, 3) + ' \u2014 worth checking whether k is right.</span>'
-        : '');
+    const widest = R.stats.filter(s => s.n > 0)
+      .reduce((a, b) => (a == null || b.width > a.width ? b : a), null);
+    const notes = [];
+    if (worst && worst.silhouette < 0.5) {
+      notes.push('<span class="warn">C' + worst.id + ' is the weakest band at silhouette ' +
+        fmt(worst.silhouette, 3) + ' \u2014 it is effectively touching its neighbour. Worth checking k.</span>');
+    }
+    const loose = R.stats.filter(s => s.n > 1 && s.density != null && s.density < 1);
+    if (loose.length) {
+      notes.push('<span class="warn">' + loose.map(s => 'C' + s.id).join(', ') +
+        (loose.length > 1 ? ' are ' : ' is ') + 'sparser than an even spread \u2014 mostly empty span ' +
+        'with a few points across it, which often means a hidden split.</span>');
+    }
+    if (!notes.length && widest) {
+      notes.push('Widest band is C' + widest.id + ' at ' + fmt(widest.width, sigDp()) +
+        '; raise k if you want it broken up.');
+    }
+    notes.push('<a href="#explainPanel" class="text-sky-400 hover:text-sky-300">What do these mean?</a>');
+    $('statsNote').innerHTML = notes.join(' ');
 
     $('copyStatsBtn').onclick = () => {
       const head = STAT_COLS.map(c => c.h).join('\t');

--- a/clustering/script.js
+++ b/clustering/script.js
@@ -98,6 +98,7 @@
     state.grid = []; state.table = null; state.profiles = []; state.result = null;
     state.valueCol = -1; state.labelCol = -1; state.pinned = null;
     $('structure').hidden = true; $('chartPanel').hidden = true; $('resultPanel').hidden = true;
+    $('statsPanel').hidden = true;
     $('pasteBox').style.minHeight = '';
     $('dataStatus').textContent = '';
   }
@@ -195,7 +196,9 @@
     const stats = API().clusterStats(values, res.assign, state.k);
     const ramp = API().rampFor(state.k);
 
-    state.result = { values, rowIx, res, stats, ramp, skipped: state.table.rows.length - values.length };
+    const overall = API().overallStats(values, stats);
+    state.result = { values, rowIx, res, stats, ramp, overall,
+      skipped: state.table.rows.length - values.length };
     $('kBadge').textContent = res.method === 'exact'
       ? '· exact optimum' : '· fast approximation, ' + values.length + ' values';
 
@@ -203,6 +206,7 @@
     paintChart();
     paintLegend();
     paintResults();
+    paintStats();
   }
 
   function paintElbow(values) {
@@ -384,6 +388,107 @@
     $('chart').querySelectorAll('circle.hi').forEach(c => c.classList.remove('hi'));
   }
 
+
+  // ------------------------------------------------------------- statistics
+
+  /* Columns are ordered so the eye runs from "how big" through "where" to "what shape",
+     and every derived one carries its definition in the header tooltip rather than in a
+     paragraph nobody reads. */
+  const STAT_COLS = [
+    { k: 'id', h: 'Cluster', t: 'Numbered low to high by value.' },
+    { k: 'n', h: 'n', num: true, t: 'Rows in this cluster.' },
+    { k: 'share', h: '% rows', num: true, t: 'Share of all clustered rows.' },
+    { k: 'min', h: 'min', num: true },
+    { k: 'max', h: 'max', num: true },
+    { k: 'mean', h: 'mean', num: true },
+    { k: 'median', h: 'median', num: true },
+    { k: 'sd', h: 'sd', num: true, t: 'Sample standard deviation within the cluster.' },
+    { k: 'width', h: 'width', num: true, t: 'max \u2212 min: how much of the value axis the cluster occupies.' },
+    { k: 'gapNext', h: 'gap \u2192', num: true, t: 'Distance from this cluster\u2019s max to the next cluster\u2019s min. A large gap means a clean break.' },
+    { k: 'density', h: 'density', num: true, t: 'Share of rows divided by share of the value axis. Dimensionless, so it does not care about units. 1,0 = exactly as dense as an even spread; 5,0 = five times denser; below 1,0 = sparser than even. Blank when the band has zero width.' },
+    { k: 'silhouette', h: 'silhouette', num: true, t: 'How much closer a point sits to its own cluster than to the nearest other one, averaged. 1 = perfectly separated, 0 = on the boundary, negative = probably in the wrong cluster. Singletons count as 0.' }
+  ];
+
+  function statCell(col, st) {
+    const v = st[col.k];
+    if (col.k === 'id') {
+      return '<span class="swatch" style="background:' + state.result.ramp[st.id - 1] + '"></span>C' + st.id;
+    }
+    if (v == null) return '<span class="muted">\u2014</span>';
+    if (col.k === 'n') return String(v);
+    if (col.k === 'share') return fmt(v * 100, 0) + ' %';
+    if (col.k === 'density') return fmt(v, 2) + '\u00d7';
+    if (col.k === 'silhouette') return fmt(v, 3);
+    return fmt(v, sigDp());
+  }
+
+  /** Decimal places that suit the spread of the data rather than a fixed guess. */
+  function sigDp() {
+    const w = state.result ? state.result.overall.width : 1;
+    if (!(w > 0)) return 2;
+    const mag = Math.floor(Math.log10(w));
+    return Math.min(6, Math.max(0, 2 - mag));
+  }
+
+  function paintStats() {
+    const R = state.result;
+    if (!R) { $('statsPanel').hidden = true; return; }
+    $('statsPanel').hidden = false;
+    const o = R.overall;
+
+    let html = '<tr>' + STAT_COLS.map(c =>
+      '<th class="' + (c.num ? 'n' : '') + '"' + (c.t ? ' title="' + esc(c.t) + '"' : '') + '>' +
+      esc(c.h) + '</th>').join('') + '</tr>';
+
+    R.stats.forEach(st => {
+      html += '<tr>' + STAT_COLS.map(c =>
+        '<td class="' + (c.num ? 'n' : '') + '">' + statCell(c, st) + '</td>').join('') + '</tr>';
+    });
+
+    const totals = {
+      id: null, n: o.n, share: 1, min: o.min, max: o.max, mean: o.mean,
+      median: o.median, sd: o.sd, width: o.width, gapNext: null,
+      density: null, silhouette: o.silhouette
+    };
+    html += '<tr class="total">' + STAT_COLS.map(c => {
+      if (c.k === 'id') return '<td>All</td>';
+      const st = totals;
+      if (st[c.k] == null) return '<td class="n"><span class="muted">\u2014</span></td>';
+      return '<td class="n">' + statCell(c, Object.assign({ id: 1 }, st)) + '</td>';
+    }).join('') + '</tr>';
+
+    $('statsTable').innerHTML = html;
+
+    $('statsSummary').innerHTML = o.explained != null
+      ? 'k = ' + state.k + ' accounts for <b>' + fmt(o.explained * 100, 1) +
+        ' %</b> of the total spread \u00b7 mean silhouette <b>' + fmt(o.silhouette, 3) + '</b>'
+      : '';
+
+    const worst = R.stats.filter(s => s.n > 0)
+      .reduce((a, b) => (a == null || b.silhouette < a.silhouette ? b : a), null);
+    $('statsNote').innerHTML =
+      '<b>density</b> is the cluster\u2019s share of the rows divided by its share of the value axis \u2014 ' +
+      'dimensionless, so it is unaffected by units. 1,0\u00d7 is exactly as dense as an even spread, ' +
+      'higher is tighter, lower is more strung out. <b>silhouette</b> runs from 1 (cleanly separated) ' +
+      'through 0 (sitting on the boundary) to negative (likely in the wrong cluster).' +
+      (worst && worst.silhouette < 0.5
+        ? ' <span class="warn">C' + worst.id + ' has the weakest separation at ' +
+          fmt(worst.silhouette, 3) + ' \u2014 worth checking whether k is right.</span>'
+        : '');
+
+    $('copyStatsBtn').onclick = () => {
+      const head = STAT_COLS.map(c => c.h).join('\t');
+      const body = R.stats.map(st => STAT_COLS.map(c => {
+        if (c.k === 'id') return 'C' + st.id;
+        const v = st[c.k];
+        if (v == null) return '';
+        if (c.k === 'share') return fmt(v * 100, 0);
+        return typeof v === 'number' ? fmt(v, c.k === 'n' ? 0 : 6) : String(v);
+      }).join('\t')).join('\n');
+      copyText(head + '\n' + body, $('copyStatsBtn'));
+    };
+  }
+
   // ------------------------------------------------------------------ output
 
   function outputRows() {
@@ -495,19 +600,7 @@
     });
     window.addEventListener('resize', () => { if (state.result) paintChart(); });
 
-    $('copyBtn').addEventListener('click', async () => {
-      const tsv = serialise('\t');
-      try {
-        await navigator.clipboard.writeText(tsv);
-        flash($('copyBtn'), 'Copied');
-      } catch (err) {
-        const ta = document.createElement('textarea');
-        ta.value = tsv; document.body.appendChild(ta); ta.select();
-        try { document.execCommand('copy'); flash($('copyBtn'), 'Copied'); }
-        catch (e2) { flash($('copyBtn'), 'Copy failed'); }
-        document.body.removeChild(ta);
-      }
-    });
+    $('copyBtn').addEventListener('click', () => copyText(serialise('\t'), $('copyBtn')));
 
     $('csvBtn').addEventListener('click', () => {
       const sep = state.decimal === ',' ? ';' : ',';
@@ -518,6 +611,19 @@
       document.body.appendChild(a); a.click(); document.body.removeChild(a);
       URL.revokeObjectURL(url);
     });
+  }
+
+  async function copyText(text, btn) {
+    try {
+      await navigator.clipboard.writeText(text);
+      flash(btn, 'Copied');
+    } catch (err) {
+      const ta = document.createElement('textarea');
+      ta.value = text; document.body.appendChild(ta); ta.select();
+      try { document.execCommand('copy'); flash(btn, 'Copied'); }
+      catch (e2) { flash(btn, 'Copy failed'); }
+      document.body.removeChild(ta);
+    }
   }
 
   function flash(btn, msg) {

--- a/clustering/script.js
+++ b/clustering/script.js
@@ -19,8 +19,17 @@
     k: 3,
     result: null,
     points: [],
-    pinned: null
+    pinned: null,
+    runToken: 0,
+    panics: 0,
+    tabs: [],            // open cluster ids, in the order they were opened
+    active: 'overview',
+    cd: {}               // per-cluster distribution state, keyed by cluster id
   };
+
+  const INK = { text: '#7f92ad', bright: '#c3d3e6', axis: '#33496b', grid: '#1c2942',
+    brk: '#44607f', surface: '#131c2e' };
+  const ROW_CAP = 500;   // rows rendered into the results table; export is never capped
 
   const EXAMPLE = [
     'Utilisation report - beams', '',
@@ -167,11 +176,83 @@
     sel.value = String(state.labelCol);
   }
 
+
+  // ------------------------------------------------------------ worker pool
+
+  /*
+   * One worker, one generation counter. A stale reply is dropped on arrival; a stale job
+   * that is already running gets its worker terminated, because a busy worker cannot read
+   * its own queue and there is nothing else that will stop it.
+   *
+   * Terminating costs a respawn of a few milliseconds, which is far cheaper than waiting
+   * out a Fisher-Jenks pass the answer to which is already obsolete.
+   */
+  const pool = {
+    worker: null,
+    gen: 0,
+    seq: 0,
+    busy: false,
+    pending: new Map(),
+    supported: typeof Worker !== 'undefined',
+
+    spawn() {
+      if (!this.supported) return null;
+      try {
+        this.worker = new Worker('cluster_worker.js');
+        this.worker.onmessage = (e) => this.receive(e.data);
+        this.worker.onerror = () => { this.supported = false; this.worker = null; };
+      } catch (err) {
+        this.supported = false;                       // file:// and old browsers
+        this.worker = null;
+      }
+      return this.worker;
+    },
+
+    receive(msg) {
+      this.busy = false;
+      const entry = this.pending.get(msg.id);
+      this.pending.delete(msg.id);
+      if (!entry) return;
+      if (msg.gen !== this.gen) return;               // superseded while in flight
+      entry.resolve(msg);
+    },
+
+    /** Abandon everything in flight. */
+    panic() {
+      this.gen++;
+      for (const [, entry] of this.pending) entry.resolve({ ok: false, cancelled: true });
+      this.pending.clear();
+      if (this.worker && this.busy) {
+        this.worker.terminate();
+        this.worker = null;
+        state.panics++;
+      }
+      this.busy = false;
+    },
+
+    run(type, payload) {
+      if (!this.supported) return Promise.resolve(null);   // caller falls back to sync
+      if (this.busy) this.panic();
+      if (!this.worker && !this.spawn()) return Promise.resolve(null);
+      const id = ++this.seq, gen = this.gen;
+      this.busy = true;
+      return new Promise((resolve) => {
+        this.pending.set(id, { resolve });
+        this.worker.postMessage({ id, gen, type, payload });
+      });
+    }
+  };
+
+  function setBusy(on, note) {
+    $('busy').hidden = !on;
+    if (on && note) $('busy').textContent = note;
+  }
+
   // ------------------------------------------------------------- clustering
 
   function recompute() {
     if (!state.table || state.valueCol < 0) {
-      $('chartPanel').hidden = true; $('resultPanel').hidden = true;
+      ['chartPanel', 'resultPanel', 'statsPanel'].forEach(id => { $(id).hidden = true; });
       if (state.table) $('dataStatus').innerHTML += ' <span class="warn">· no numeric column to cluster</span>';
       return;
     }
@@ -185,34 +266,51 @@
     const maxK = Math.min(12, values.length);
     state.k = Math.max(1, Math.min(maxK, Math.round(num($('kInput').value) || 3)));
     $('kInput').value = state.k;
+    if (!values.length) return;
 
-    let res;
-    try { res = API().clusterValues(values, state.k); }
-    catch (e) {
-      $('elbowNote').innerHTML = '<span class="warn">' + esc(e.message) + '</span>';
-      return;
-    }
+    const token = ++state.runToken;
+    setBusy(true, 'clustering ' + values.length.toLocaleString('en') + ' values…');
 
-    const stats = API().clusterStats(values, res.assign, state.k);
-    const ramp = API().rampFor(state.k);
+    pool.run('cluster', { values, k: state.k }).then((msg) => {
+      if (token !== state.runToken) return;                    // a newer run took over
+      if (msg && msg.cancelled) return;
+      let res, stats, overall, ms = msg ? msg.ms : null;
+      if (msg && msg.ok) {
+        ({ res, stats, overall } = msg.result);
+      } else {
+        if (msg && msg.error) { $('elbowNote').innerHTML = '<span class="warn">' + esc(msg.error) + '</span>'; setBusy(false); return; }
+        // no worker available: do it here rather than refusing
+        const t0 = performance.now();
+        try { res = API().clusterValues(values, state.k); }
+        catch (e) { $('elbowNote').innerHTML = '<span class="warn">' + esc(e.message) + '</span>'; setBusy(false); return; }
+        stats = API().clusterStats(values, res.assign, state.k);
+        overall = API().overallStats(values, stats);
+        ms = Math.round(performance.now() - t0);
+      }
 
-    const overall = API().overallStats(values, stats);
-    state.result = { values, rowIx, res, stats, ramp, overall,
-      skipped: state.table.rows.length - values.length };
-    $('kBadge').textContent = res.method === 'exact'
-      ? '· exact optimum' : '· fast approximation, ' + values.length + ' values';
+      const ramp = API().rampFor(state.k);
+      state.result = { values, rowIx, res, stats, ramp, overall, ms,
+        skipped: state.table.rows.length - values.length };
 
-    paintElbow(values);
-    paintChart();
-    paintLegend();
-    paintResults();
-    paintStats();
+      $('kBadge').innerHTML = (res.method === 'exact' ? '· exact optimum' : '· fast approximation') +
+        ' · ' + values.length.toLocaleString('en') + ' values' +
+        (ms != null ? ' · ' + ms + ' ms' : '') +
+        (pool.supported ? '' : ' · <span class="warn">no worker, computed on the page</span>');
+
+      setBusy(false);
+      paintElbow(values);
+      paintChart();
+      paintLegend();
+      paintResults();
+      paintStats();
+      refreshOpenTabs();
+    });
   }
 
   function paintElbow(values) {
     const kMax = Math.min(10, values.length);
     if (kMax < 2) { $('elbow').innerHTML = ''; $('elbowNote').textContent = ''; return; }
-    const scan = API().elbowScan(values, kMax);
+    const scan = API().elbowScan(values, kMax);   // Lloyd path only, cheap even at 10^5
     $('elbow').innerHTML = scan.rows.map(r =>
       '<div class="ecol"><button data-k="' + r.k + '" class="' + (r.k === state.k ? 'on ' : '') +
       (r.k === scan.elbowK ? 'elb' : '') +
@@ -231,6 +329,40 @@
         : '');
   }
 
+
+  // ---------------------------------------------------------------- canvas
+
+  /** Size a canvas to its CSS box at device resolution and return a CSS-pixel context. */
+  function ctxFor(canvas, cssW, cssH) {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.max(1, Math.round(cssW * dpr));
+    canvas.height = Math.max(1, Math.round(cssH * dpr));
+    const ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+    return ctx;
+  }
+
+  function text(ctx, str, x, y, align, fill, weight) {
+    ctx.fillStyle = fill || INK.text;
+    ctx.font = (weight ? weight + ' ' : '') + '10px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = align || 'left';
+    ctx.textBaseline = 'alphabetic';
+    ctx.fillText(str, x, y);
+  }
+
+  function line(ctx, x1, y1, x2, y2, stroke, dash) {
+    ctx.save();
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 1;
+    if (dash) ctx.setLineDash(dash);
+    ctx.beginPath();
+    ctx.moveTo(Math.round(x1) + 0.5, Math.round(y1) + 0.5);
+    ctx.lineTo(Math.round(x2) + 0.5, Math.round(y2) + 0.5);
+    ctx.stroke();
+    ctx.restore();
+  }
+
   // ------------------------------------------------------------------- chart
 
   const M = { t: 12, r: 54, b: 26, l: 52 };
@@ -240,11 +372,12 @@
     if (!R) return;
     $('chartPanel').hidden = false;
 
-    const svg = $('chart');
-    const W = svg.clientWidth || svg.parentElement.clientWidth || 900;
+    const wrap = $('chartWrap');
+    const W = wrap.clientWidth || 900;
     const H = Math.max(430, Math.min(760, 200 + R.values.length * 1.8));
-    svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
-    svg.setAttribute('height', H);
+    wrap.style.height = H + 'px';
+    const ctx = ctxFor($('chart'), W, H);
+    ctxFor($('chartOver'), W, H);
 
     const useLabelX = $('xMode').value === 'label' && state.labelCol >= 0;
     const xs = R.rowIx.map((ri, j) => {
@@ -263,63 +396,55 @@
 
     const px = (v) => M.l + (v - xMin) / xSpan * (W - M.l - M.r);
     const py = (v) => H - M.b - (v - y0) / (y1 - y0) * (H - M.t - M.b);
+    state.scale = { px, py, W, H };
 
-    let g = '';
-
-    // horizontal grid + y ticks
     const ticks = niceTicks(y0, y1, 5);
-    g += '<g class="grid">' + ticks.map(t =>
-      '<line x1="' + M.l + '" x2="' + (W - M.r) + '" y1="' + py(t).toFixed(1) + '" y2="' + py(t).toFixed(1) + '"/>').join('') + '</g>';
-    g += '<g>' + ticks.map(t =>
-      '<text x="' + (M.l - 6) + '" y="' + (py(t) + 3).toFixed(1) + '" text-anchor="end">' + esc(fmt(t)) + '</text>').join('') + '</g>';
-
-    // axes
-    g += '<g class="axis"><line x1="' + M.l + '" x2="' + M.l + '" y1="' + M.t + '" y2="' + (H - M.b) + '"/>' +
-      '<line x1="' + M.l + '" x2="' + (W - M.r) + '" y1="' + (H - M.b) + '" y2="' + (H - M.b) + '"/></g>';
-
-    // x ticks, sparse
-    const xt = niceTicks(xMin, xMax, 6).filter(t => t >= xMin && t <= xMax);
-    g += '<g>' + xt.map(t => '<text x="' + px(t).toFixed(1) + '" y="' + (H - M.b + 14) + '" text-anchor="middle">' +
-      esc(fmt(t)) + '</text>').join('') + '</g>';
-
-    // Cluster breaks carry their value just inside the left edge; the band labels live in
-    // the right margin. Keeping them on opposite sides is what stops them colliding when
-    // the bands are thin.
-    R.res.breaks.forEach((b) => {
-      const yy = py(b).toFixed(1);
-      g += '<line class="brk" x1="' + M.l + '" x2="' + (W - M.r) + '" y1="' + yy + '" y2="' + yy + '"/>';
-      g += '<text x="' + (M.l + 5) + '" y="' + (+yy - 3) + '" style="fill:#8fa3bd">' + esc(fmt(b)) + '</text>';
+    ticks.forEach(t => {
+      line(ctx, M.l, py(t), W - M.r, py(t), INK.grid);
+      text(ctx, fmt(t), M.l - 6, py(t) + 3, 'right');
     });
+    line(ctx, M.l, M.t, M.l, H - M.b, INK.axis);
+    line(ctx, M.l, H - M.b, W - M.r, H - M.b, INK.axis);
+    niceTicks(xMin, xMax, 6).filter(t => t >= xMin && t <= xMax)
+      .forEach(t => text(ctx, fmt(t), px(t), H - M.b + 14, 'center'));
+
+    R.res.breaks.forEach((b) => {
+      const yy = py(b);
+      line(ctx, M.l, yy, W - M.r, yy, INK.brk, [3, 3]);
+      text(ctx, fmt(b), M.l + 5, yy - 3, 'left', '#8fa3bd');
+    });
+
+    // points: one arc per row, but no DOM node per row
+    state.points = [];
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = INK.surface;
+    for (let j = 0; j < R.values.length; j++) {
+      const cx = px(xs[j]), cy = py(R.values[j]), cid = R.res.assign[j];
+      state.points.push({ cx, cy, j, rowIx: R.rowIx[j], value: R.values[j], cluster: cid });
+      ctx.beginPath();
+      ctx.arc(cx, cy, 3.5, 0, 6.2832);
+      ctx.fillStyle = R.ramp[cid - 1];
+      ctx.fill();
+      if (R.values.length <= 6000) ctx.stroke();     // rings cost more than they give at scale
+    }
+
     R.stats.forEach((st) => {
       if (!st.n) return;
       const top = py(st.max), bot = py(st.min);
-      if (bot - top < 11 && R.stats.length > 8) return;      // no room, legend carries it
-      const mid = (top + bot) / 2;
-      g += '<text x="' + (W - M.r + 6) + '" y="' + (mid + 3.5).toFixed(1) +
-        '" style="fill:' + R.ramp[st.id - 1] + ';font-weight:700">C' + st.id + '</text>';
+      if (bot - top < 11 && R.stats.length > 8) return;
+      text(ctx, 'C' + st.id, W - M.r + 6, (top + bot) / 2 + 3.5, 'left', R.ramp[st.id - 1], 'bold');
     });
 
-    // points
-    state.points = [];
-    let marks = '';
-    R.values.forEach((v, j) => {
-      const cx = px(xs[j]), cy = py(v);
-      const cid = R.res.assign[j];
-      state.points.push({ cx, cy, j, rowIx: R.rowIx[j], value: v, cluster: cid });
-      marks += '<circle cx="' + cx.toFixed(1) + '" cy="' + cy.toFixed(1) + '" r="3.5" fill="' +
-        R.ramp[cid - 1] + '" data-j="' + j + '"/>';
-    });
-    g += marks;
+    text(ctx, useLabelX ? state.table.columns[state.labelCol] : 'row order',
+      (M.l + W - M.r) / 2, H - 4, 'center');
+    ctx.save();
+    ctx.translate(12, (M.t + H - M.b) / 2);
+    ctx.rotate(-Math.PI / 2);
+    text(ctx, state.table.columns[state.valueCol], 0, 0, 'center');
+    ctx.restore();
 
-    // axis titles
-    g += '<text x="' + ((M.l + W - M.r) / 2) + '" y="' + (H - 2) + '" text-anchor="middle">' +
-      (useLabelX ? esc(state.table.columns[state.labelCol]) : 'row order') + '</text>';
-    g += '<text transform="translate(12,' + ((M.t + H - M.b) / 2) + ') rotate(-90)" text-anchor="middle">' +
-      esc(state.table.columns[state.valueCol]) + '</text>';
-
-    svg.innerHTML = g;
     $('chartTitle').innerHTML = esc(state.table.columns[state.valueCol]) + ' in ' + state.k +
-      ' clusters · ' + R.values.length + ' points' +
+      ' clusters · ' + R.values.length.toLocaleString('en') + ' points' +
       (R.skipped ? ' · <span class="warn">' + R.skipped + ' rows without a number</span>' : '');
   }
 
@@ -337,20 +462,23 @@
   function paintLegend() {
     const R = state.result;
     $('legend').innerHTML = R.stats.map(s =>
-      '<div class="muted"><span class="swatch" style="background:' + R.ramp[s.id - 1] + '"></span>' +
+      '<button type="button" class="muted" data-open="' + s.id + '" style="background:none;border:0;' +
+      'cursor:' + (s.n ? 'pointer' : 'default') + ';padding:0;text-align:left"' +
+      (s.n ? ' title="Open the distribution of C' + s.id + '"' : '') + '>' +
+      '<span class="swatch" style="background:' + R.ramp[s.id - 1] + '"></span>' +
       '<b style="color:#e6edf6">C' + s.id + '</b> · n = ' + s.n +
-      (s.n ? ' · ' + fmt(s.min) + ' … ' + fmt(s.max) : '') + '</div>').join('');
+      (s.n ? ' · ' + fmt(s.min) + ' … ' + fmt(s.max) + ' <span style="color:#38bdf8">›</span>' : '') +
+      '</button>').join('');
+    $('legend').querySelectorAll('[data-open]').forEach(b =>
+      b.addEventListener('click', () => openCluster(parseInt(b.dataset.open, 10))));
   }
 
   // -------------------------------------------------------------- hover
 
   function pointAt(evt) {
-    const svg = $('chart');
-    const rect = svg.getBoundingClientRect();
-    const vb = svg.viewBox.baseVal;
-    const sx = vb.width / rect.width, sy = vb.height / rect.height;
-    const x = (evt.clientX - rect.left) * sx, y = (evt.clientY - rect.top) * sy;
-    let best = null, bestD = 14 * Math.max(sx, sy);
+    const rect = $('chart').getBoundingClientRect();
+    const x = evt.clientX - rect.left, y = evt.clientY - rect.top;
+    let best = null, bestD = 14;
     for (const p of state.points) {
       const d = Math.hypot(p.cx - x, p.cy - y);
       if (d < bestD) { bestD = d; best = p; }
@@ -358,14 +486,25 @@
     return best;
   }
 
+  function highlight(p) {
+    const sc = state.scale;
+    if (!sc) return;
+    const ctx = ctxFor($('chartOver'), sc.W, sc.H);
+    if (!p) return;
+    ctx.beginPath();
+    ctx.arc(p.cx, p.cy, 5.5, 0, 6.2832);
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
   function showTip(p, evt) {
-    const R = state.result;
     const row = state.table.rows[p.rowIx];
     const heading = state.labelCol >= 0 ? row[state.labelCol] : 'Row ' + (p.rowIx + 1);
     let html = '<b>' + esc(heading || 'Row ' + (p.rowIx + 1)) + '</b><table>';
     state.table.columns.forEach((c, i) => {
-      const hl = i === state.valueCol ? ' class="hl"' : '';
-      html += '<tr' + hl + '><td class="k">' + esc(c) + '</td><td>' + esc(row[i]) + '</td></tr>';
+      html += '<tr' + (i === state.valueCol ? ' class="hl"' : '') + '><td class="k">' + esc(c) +
+        '</td><td>' + esc(row[i]) + '</td></tr>';
     });
     html += '<tr class="hl"><td class="k">Cluster</td><td>C' + p.cluster + '</td></tr></table>';
     const tip = $('tip');
@@ -376,18 +515,14 @@
     if (x + b.width > window.innerWidth - 8) x = evt.clientX - b.width - 14;
     if (y + b.height > window.innerHeight - 8) y = Math.max(8, evt.clientY - b.height - 14);
     tip.style.left = x + 'px'; tip.style.top = y + 'px';
-
-    $('chart').querySelectorAll('circle.hi').forEach(c => c.classList.remove('hi'));
-    const el = $('chart').querySelector('circle[data-j="' + p.j + '"]');
-    if (el) { el.classList.add('hi'); el.parentNode.appendChild(el); }
+    highlight(p);
   }
 
   function hideTip() {
     if (state.pinned) return;
     $('tip').style.display = 'none';
-    $('chart').querySelectorAll('circle.hi').forEach(c => c.classList.remove('hi'));
+    highlight(null);
   }
-
 
   // ------------------------------------------------------------- statistics
 
@@ -441,8 +576,10 @@
       esc(c.h) + '</th>').join('') + '</tr>';
 
     R.stats.forEach(st => {
-      html += '<tr>' + STAT_COLS.map(c =>
-        '<td class="' + (c.num ? 'n' : '') + '">' + statCell(c, st) + '</td>').join('') + '</tr>';
+      html += '<tr data-open="' + st.id + '" style="cursor:' + (st.n ? 'pointer' : 'default') + '"' +
+        (st.n ? ' title="Open the distribution of C' + st.id + '"' : '') + '>' +
+        STAT_COLS.map(c => '<td class="' + (c.num ? 'n' : '') + '">' + statCell(c, st) + '</td>').join('') +
+        '</tr>';
     });
 
     const totals = {
@@ -458,6 +595,8 @@
     }).join('') + '</tr>';
 
     $('statsTable').innerHTML = html;
+    $('statsTable').querySelectorAll('[data-open]').forEach(tr =>
+      tr.addEventListener('click', () => openCluster(parseInt(tr.dataset.open, 10))));
 
     $('statsSummary').innerHTML = o.explained != null
       ? 'k = ' + state.k + ' accounts for <b>' + fmt(o.explained * 100, 1) +
@@ -525,7 +664,9 @@
     const R = state.result;
     $('resultPanel').hidden = false;
     let html = '<tr>' + cols.map(c => '<th>' + esc(c) + '</th>').join('') + '</tr>';
-    rows.forEach(r => {
+    // A 100 000-row DOM table is unreadable and freezes the tab; the exports are not capped.
+    const shown = rows.length > ROW_CAP ? rows.slice(0, ROW_CAP) : rows;
+    shown.forEach(r => {
       html += '<tr>' + r.map((v, i) => {
         if (cols[i] === 'Cluster' && v !== '—') {
           return '<td><span class="swatch" style="background:' + R.ramp[+v - 1] + '"></span>C' + esc(v) + '</td>';
@@ -534,7 +675,11 @@
       }).join('') + '</tr>';
     });
     $('resTable').innerHTML = html;
-    $('resultStatus').textContent = rows.length + ' rows' + (R.skipped ? ', ' + R.skipped + ' without a number' : '');
+    $('resultStatus').innerHTML = rows.length.toLocaleString('en') + ' rows' +
+      (R.skipped ? ', ' + R.skipped + ' without a number' : '') +
+      (rows.length > ROW_CAP
+        ? ' · <span class="warn">showing the first ' + ROW_CAP + '</span> — copy and download give you all of them'
+        : '');
   }
 
   function serialise(sep) {
@@ -545,6 +690,219 @@
         ? '"' + s.replace(/"/g, '""') + '"' : s;
     };
     return [cols.map(q).join(sep)].concat(rows.map(r => r.map(q).join(sep))).join('\n');
+  }
+
+
+  // ------------------------------------------------------ tabs + distribution
+
+  function openCluster(id) {
+    if (!state.result || !state.result.stats[id - 1] || !state.result.stats[id - 1].n) return;
+    if (state.tabs.indexOf(id) < 0) state.tabs.push(id);
+    state.active = id;
+    paintTabs();
+    showView();
+  }
+
+  function closeCluster(id) {
+    state.tabs = state.tabs.filter(t => t !== id);
+    delete state.cd[id];
+    if (state.active === id) state.active = 'overview';
+    paintTabs();
+    showView();
+  }
+
+  function paintTabs() {
+    const R = state.result;
+    const wrap = $('tabs');
+    if (!R) { wrap.hidden = true; return; }
+    wrap.hidden = false;
+    let html = '<button type="button" class="tab ' + (state.active === 'overview' ? 'on' : '') +
+      '" data-tab="overview">Overview</button>';
+    state.tabs.forEach(id => {
+      const st = R.stats[id - 1];
+      html += '<button type="button" class="tab ' + (state.active === id ? 'on' : '') + '" data-tab="' + id + '">' +
+        '<span class="tabdot" style="background:' + R.ramp[id - 1] + '"></span>C' + id +
+        '<span class="muted" style="font-size:.7rem">' + (st ? st.n : 0) + '</span>' +
+        '<span class="x" data-close="' + id + '" title="close">\u00d7</span></button>';
+    });
+    wrap.innerHTML = html;
+    wrap.querySelectorAll('[data-tab]').forEach(b => b.addEventListener('click', (e) => {
+      const close = e.target.closest('[data-close]');
+      if (close) { closeCluster(parseInt(close.dataset.close, 10)); return; }
+      state.active = b.dataset.tab === 'overview' ? 'overview' : parseInt(b.dataset.tab, 10);
+      paintTabs(); showView();
+    }));
+  }
+
+  function showView() {
+    const cluster = state.active !== 'overview';
+    $('viewOverview').hidden = cluster;
+    $('viewCluster').hidden = !cluster;
+    if (cluster) paintDistribution(state.active);
+    else if (state.result) paintChart();
+  }
+
+  /** Drop any open tab whose cluster no longer exists after a re-run. */
+  function refreshOpenTabs() {
+    const R = state.result;
+    if (!R) { state.tabs = []; state.active = 'overview'; state.cd = {}; paintTabs(); return; }
+    state.tabs = state.tabs.filter(id => R.stats[id - 1] && R.stats[id - 1].n > 0);
+    state.tabs.forEach(id => { if (state.cd[id]) state.cd[id].sorted = null; });
+    if (state.active !== 'overview' && state.tabs.indexOf(state.active) < 0) state.active = 'overview';
+    paintTabs();
+    showView();
+  }
+
+  /** Sorted values and prefix sums for one cluster, built once and reused. */
+  function clusterSeries(id) {
+    const R = state.result;
+    let cd = state.cd[id];
+    if (!cd) cd = state.cd[id] = { threshold: null, bins: null, sorted: null };
+    if (!cd.sorted) {
+      const vals = [];
+      for (let j = 0; j < R.values.length; j++) if (R.res.assign[j] === id) vals.push(R.values[j]);
+      vals.sort((a, b) => a - b);
+      cd.sorted = vals;
+      cd.prefix = API().prefixSums(vals);
+      if (cd.bins == null) cd.bins = API().suggestBins(vals);
+      if (cd.threshold == null || cd.threshold < vals[0] || cd.threshold > vals[vals.length - 1]) {
+        cd.threshold = vals[Math.floor((vals.length - 1) / 2)];
+      }
+    }
+    return cd;
+  }
+
+  const CD = { t: 16, r: 18, b: 46, l: 54, stripH: 74 };
+
+  function paintDistribution(id) {
+    const R = state.result;
+    const st = R.stats[id - 1];
+    const cd = clusterSeries(id);
+    const v = cd.sorted, n = v.length;
+    const colour = R.ramp[id - 1];
+
+    $('cdTitle').innerHTML = '<span class="tabdot" style="display:inline-block;background:' + colour +
+      ';margin-right:.4rem"></span>Cluster C' + id + ' · distribution of ' +
+      esc(state.table.columns[state.valueCol]);
+    $('cdMeta').innerHTML = n.toLocaleString('en') + ' points · ' + fmt(st.min) + ' … ' + fmt(st.max) +
+      ' · mean ' + fmt(st.mean) + ' · sd ' + fmt(st.sd);
+
+    const lo = v[0], hi = v[n - 1];
+    const sl = $('cdSlider');
+    sl.min = 0; sl.max = 1000;
+    sl.value = hi > lo ? Math.round((cd.threshold - lo) / (hi - lo) * 1000) : 500;
+    $('cdBins').min = 2;
+    $('cdBins').max = Math.max(8, Math.min(120, n));
+    $('cdBins').value = cd.bins;
+    $('cdBinsOut').textContent = cd.bins + ' bins';
+
+    cd.hist = API().histogram(v, cd.bins);
+    drawDistBase(cd, colour);
+    updateThreshold(id, cd.threshold, true);
+  }
+
+  function distGeom(cd) {
+    const wrap = $('cdWrap');
+    const W = wrap.clientWidth || 800, H = wrap.clientHeight || 340;
+    const lo = cd.hist.lo, hi = cd.hist.hi;
+    const span = (hi - lo) || 1;
+    const px = (x) => CD.l + (x - lo) / span * (W - CD.l - CD.r);
+    const histBottom = H - CD.b - CD.stripH;
+    return { W, H, lo, hi, px, histBottom, stripTop: histBottom + 12 };
+  }
+
+  /** Histogram on top, the raw points as a jittered strip below, one shared x axis. */
+  function drawDistBase(cd, colour) {
+    const g = distGeom(cd);
+    const ctx = ctxFor($('cdBase'), g.W, g.H);
+    const h = cd.hist;
+
+    const yTicks = niceTicks(0, h.max, 4);
+    yTicks.forEach(t => {
+      const y = g.histBottom - (t / (h.max || 1)) * (g.histBottom - CD.t);
+      line(ctx, CD.l, y, g.W - CD.r, y, INK.grid);
+      text(ctx, String(Math.round(t)), CD.l - 6, y + 3, 'right');
+    });
+
+    ctx.fillStyle = colour;
+    h.bins.forEach(b => {
+      if (!b.n) return;
+      const x0 = g.px(b.lo), x1 = g.px(b.hi);
+      const y = g.histBottom - (b.n / (h.max || 1)) * (g.histBottom - CD.t);
+      ctx.fillRect(x0 + 1, y, Math.max(1, x1 - x0 - 2), g.histBottom - y);
+    });
+
+    line(ctx, CD.l, g.histBottom, g.W - CD.r, g.histBottom, INK.axis);
+    text(ctx, 'count', CD.l - 6, CD.t - 4, 'right');
+
+    // strip of the actual points, jittered so overlaps are visible
+    const stripMid = g.stripTop + CD.stripH / 2;
+    ctx.fillStyle = colour;
+    ctx.globalAlpha = cd.sorted.length > 4000 ? 0.35 : 0.75;
+    for (let i = 0; i < cd.sorted.length; i++) {
+      const x = g.px(cd.sorted[i]);
+      const jitter = ((i * 2654435761) % 1000) / 1000 - 0.5;   // deterministic, no Math.random
+      ctx.beginPath();
+      ctx.arc(x, stripMid + jitter * (CD.stripH - 14), 2.4, 0, 6.2832);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    line(ctx, CD.l, g.H - CD.b + 6, g.W - CD.r, g.H - CD.b + 6, INK.axis);
+    niceTicks(g.lo, g.hi, 6).filter(t => t >= g.lo && t <= g.hi)
+      .forEach(t => text(ctx, fmt(t), g.px(t), g.H - CD.b + 20, 'center'));
+    text(ctx, state.table.columns[state.valueCol], (CD.l + g.W - CD.r) / 2, g.H - 6, 'center');
+    text(ctx, 'points', CD.l - 6, stripMid + 3, 'right');
+  }
+
+  /**
+   * Repaint only the overlay: the threshold line and the shading either side. The
+   * histogram and the strip underneath are untouched, which is what keeps this cheap
+   * enough to run on every pointer move.
+   */
+  function updateThreshold(id, x, force) {
+    const cd = state.cd[id];
+    if (!cd || !cd.sorted) return;
+    const t0 = performance.now();
+    cd.threshold = x;
+
+    const g = distGeom(cd);
+    const ctx = ctxFor($('cdOver'), g.W, g.H);
+    const xp = g.px(x);
+
+    ctx.fillStyle = 'rgba(148,163,184,.10)';
+    ctx.fillRect(CD.l, CD.t, Math.max(0, xp - CD.l), g.H - CD.b - CD.t + 6);
+    line(ctx, xp, CD.t - 4, xp, g.H - CD.b + 6, '#ffffff');
+    ctx.fillStyle = '#e6edf6';
+    ctx.font = 'bold 10px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = xp > g.W * 0.75 ? 'right' : 'left';
+    ctx.fillText(fmt(x), xp + (xp > g.W * 0.75 ? -5 : 5), CD.t + 4);
+
+    const s = API().thresholdStats(cd.sorted, cd.prefix, x);
+    const R = state.result;
+    const cells = [
+      ['at or below', s.below.toLocaleString('en'), fmt(s.belowShare * 100, 1) + ' %'],
+      ['above', s.above.toLocaleString('en'), fmt(s.aboveShare * 100, 1) + ' %'],
+      ['mean below', s.meanBelow == null ? '—' : fmt(s.meanBelow), ''],
+      ['mean above', s.meanAbove == null ? '—' : fmt(s.meanAbove), ''],
+      ['percentile', fmt(s.percentile * 100, 1), 'of this band']
+    ];
+    $('cdReadout').innerHTML = cells.map(c =>
+      '<div class="read"><b>' + esc(c[1]) + (c[2] && c[0].indexOf('mean') < 0 ?
+        ' <span style="font-size:.8rem;color:#7dd3fc">' + esc(c[2]) + '</span>' : '') +
+      '</b><span>' + esc(c[0]) + (c[0] === 'percentile' ? ' %' : '') + '</span></div>').join('');
+
+    $('cdValue').value = fmt(x);
+    $('cdPerf').textContent = 'threshold recomputed in ' +
+      (performance.now() - t0).toFixed(2) + ' ms · binary search, never cancelled' +
+      (state.panics ? ' · ' + state.panics + ' clustering pass' + (state.panics > 1 ? 'es' : '') + ' abandoned' : '');
+    void force; void R;
+  }
+
+  function sliderToValue(id) {
+    const cd = state.cd[id];
+    const v = cd.sorted, lo = v[0], hi = v[v.length - 1];
+    return lo + (+$('cdSlider').value / 1000) * (hi - lo);
   }
 
   // ------------------------------------------------------------------ wiring
@@ -592,14 +950,18 @@
       rd.readAsText(f);
     });
 
-    const svg = $('chart');
-    svg.addEventListener('mousemove', e => {
+    const plot = $('chart');   // a canvas now, but the same pointer handling
+    plot.addEventListener('mousemove', e => {
       if (state.pinned) return;
       const p = pointAt(e);
       if (p) showTip(p, e); else hideTip();
     });
-    svg.addEventListener('mouseleave', hideTip);
-    svg.addEventListener('click', e => {
+    plot.addEventListener('mouseleave', hideTip);
+    plot.addEventListener('dblclick', e => {
+      const p = pointAt(e);
+      if (p) { state.pinned = null; hideTip(); openCluster(p.cluster); }
+    });
+    plot.addEventListener('click', e => {
       const p = pointAt(e);
       if (!p) { state.pinned = null; hideTip(); return; }
       if (state.pinned && state.pinned.j === p.j) { state.pinned = null; hideTip(); }
@@ -608,9 +970,70 @@
     document.addEventListener('keydown', e => {
       if (e.key === 'Escape') { state.pinned = null; hideTip(); }
     });
-    window.addEventListener('resize', () => { if (state.result) paintChart(); });
+    let resizeT = null;
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeT);
+      resizeT = setTimeout(() => {
+        if (!state.result) return;
+        if (state.active === 'overview') paintChart(); else paintDistribution(state.active);
+      }, 120);
+    });
 
     $('copyBtn').addEventListener('click', () => copyText(serialise('\t'), $('copyBtn')));
+
+    // The slider runs through rAF so several input events inside one frame collapse into
+    // a single repaint - the 60 Hz ceiling the readout is quoted against.
+    let rafPending = false;
+    const onSlide = () => {
+      if (state.active === 'overview' || rafPending) return;
+      rafPending = true;
+      requestAnimationFrame(() => {
+        rafPending = false;
+        updateThreshold(state.active, sliderToValue(state.active));
+      });
+    };
+    $('cdSlider').addEventListener('input', onSlide);
+    $('cdValue').addEventListener('change', () => {
+      if (state.active === 'overview') return;
+      const cd = state.cd[state.active], v = cd.sorted;
+      const x = Math.min(v[v.length - 1], Math.max(v[0], num($('cdValue').value)));
+      if (x == null || !isFinite(x)) { updateThreshold(state.active, cd.threshold); return; }
+      $('cdSlider').value = Math.round((x - v[0]) / ((v[v.length - 1] - v[0]) || 1) * 1000);
+      updateThreshold(state.active, x);
+    });
+    $('cdMedian').addEventListener('click', () => {
+      if (state.active === 'overview') return;
+      const st = state.result.stats[state.active - 1];
+      const cd = state.cd[state.active], v = cd.sorted;
+      $('cdSlider').value = Math.round((st.median - v[0]) / ((v[v.length - 1] - v[0]) || 1) * 1000);
+      updateThreshold(state.active, st.median);
+    });
+    $('cdBins').addEventListener('input', () => {
+      if (state.active === 'overview') return;
+      const cd = state.cd[state.active];
+      cd.bins = parseInt($('cdBins').value, 10);
+      $('cdBinsOut').textContent = cd.bins + ' bins';
+      cd.hist = API().histogram(cd.sorted, cd.bins);
+      drawDistBase(cd, state.result.ramp[state.active - 1]);
+      updateThreshold(state.active, cd.threshold);
+    });
+    $('cdAutoBins').addEventListener('click', () => {
+      if (state.active === 'overview') return;
+      const cd = state.cd[state.active];
+      cd.bins = API().suggestBins(cd.sorted);
+      $('cdBins').value = cd.bins;
+      $('cdBins').dispatchEvent(new Event('input'));
+    });
+    $('cdWrap').addEventListener('click', (e) => {
+      if (state.active === 'overview') return;
+      const cd = state.cd[state.active];
+      const g = distGeom(cd);
+      const rect = $('cdBase').getBoundingClientRect();
+      const frac = (e.clientX - rect.left - CD.l) / (g.W - CD.l - CD.r);
+      const x = Math.min(g.hi, Math.max(g.lo, g.lo + frac * (g.hi - g.lo)));
+      $('cdSlider').value = Math.round((x - g.lo) / ((g.hi - g.lo) || 1) * 1000);
+      updateThreshold(state.active, x);
+    });
 
     $('csvBtn').addEventListener('click', () => {
       const sep = state.decimal === ',' ? ';' : ',';

--- a/clustering/test.js
+++ b/clustering/test.js
@@ -153,6 +153,39 @@ eq('every step is a valid hex colour',
   A.rampFor(12).every(c => /^#[0-9a-f]{6}$/.test(c)), true);
 eq('ramp is deterministic', A.rampFor(9).join(), A.rampFor(9).join());
 
+// ---- histogram and threshold (the distribution view)
+const dv = [1, 2, 2, 3, 3, 3, 4, 4, 5, 9];
+const dpre = A.prefixSums(dv);
+eq('prefix sums', Array.from(dpre), [0, 1, 3, 5, 8, 11, 14, 18, 22, 27, 36]);
+eq('upperBound below everything', A.upperBound(dv, 0), 0);
+eq('upperBound is inclusive of equals', A.upperBound(dv, 3), 6);
+eq('upperBound above everything', A.upperBound(dv, 99), dv.length);
+
+const hh = A.histogram(dv, 4);
+eq('histogram bin count', hh.bins.length, 4);
+eq('every value lands in exactly one bin', hh.bins.reduce((a, b) => a + b.n, 0), dv.length);
+eq('histogram spans the data', [hh.lo, hh.hi], [1, 9]);
+eq('tallest bin is reported', hh.max, Math.max.apply(null, hh.bins.map(b => b.n)));
+eq('histogram of one value does not divide by zero', A.histogram([5, 5, 5], 4).bins.length, 4);
+eq('empty histogram is empty', A.histogram([], 4).bins.length, 0);
+eq('bin count is clamped', A.histogram(dv, 9999).bins.length, 500);
+
+const ts = A.thresholdStats(dv, dpre, 3);
+eq('threshold splits at or below / above', [ts.below, ts.above], [6, 4]);
+near('shares sum to one', ts.belowShare + ts.aboveShare, 1, 1e-12);
+near('mean below', ts.meanBelow, 14 / 6, 1e-12);
+near('mean above', ts.meanAbove, (36 - 14) / 4, 1e-12);
+eq('threshold above the top leaves nothing above', A.thresholdStats(dv, dpre, 99).above, 0);
+eq('nothing above means no mean above', A.thresholdStats(dv, dpre, 99).meanAbove, null);
+eq('threshold below the bottom leaves nothing below', A.thresholdStats(dv, dpre, -1).below, 0);
+eq('empty series has no threshold stats', A.thresholdStats([], A.prefixSums([]), 1), null);
+eq('percentile matches the below share', A.thresholdStats(dv, dpre, 4).percentile,
+  A.thresholdStats(dv, dpre, 4).belowShare);
+
+eq('suggestBins is sane on a spread', A.suggestBins(dv) >= 1 && A.suggestBins(dv) <= 120, true);
+eq('suggestBins on identical values', A.suggestBins([2, 2, 2]), 1);
+eq('suggestBins on a single value', A.suggestBins([7]), 1);
+
 // ---- quoted delimiters survive
 eq('quoted delimiter', A.splitRow('a;"b;c";d', ';'), ['a', 'b;c', 'd']);
 

--- a/clustering/test.js
+++ b/clustering/test.js
@@ -108,6 +108,38 @@ eq('elbow scan length', el.rows.length, 6);
 eq('wcss falls as k rises', el.rows.every((r, i) => i === 0 || r.wcss <= el.rows[i - 1].wcss + 1e-9), true);
 eq('elbow finds the three real groups', el.elbowK, 3);
 
+// ---- per-cluster statistics
+const sv = [0.16, 0.18, 0.21, 0.41, 0.42, 0.44, 0.45, 0.66, 0.68, 0.70, 0.71, 0.91, 0.93, 0.95, 0.97];
+const sr = A.clusterValues(sv, 4);
+const ss = A.clusterStats(sv, sr.assign, 4);
+eq('stats: one row per cluster', ss.length, 4);
+eq('stats: counts sum to n', ss.reduce((a, b) => a + b.n, 0), sv.length);
+eq('stats: shares sum to 1', Math.abs(ss.reduce((a, b) => a + b.share, 0) - 1) < 1e-12, true);
+near('stats: mean of the low band', ss[0].mean, (0.16 + 0.18 + 0.21) / 3, 1e-12);
+near('stats: median of a 4-point band', ss[1].median, (0.42 + 0.44) / 2, 1e-12);
+near('stats: width is max - min', ss[0].width, 0.21 - 0.16, 1e-12);
+near('stats: gap to the next cluster', ss[0].gapNext, 0.41 - 0.21, 1e-12);
+eq('stats: last cluster has no gap', ss[3].gapNext, null);
+eq('stats: sd of a singleton is 0', A.clusterStats([1, 5], [1, 2], 2)[0].sd, 0);
+eq('stats: zero-width band reports no density', A.clusterStats([1, 5], [1, 2], 2)[0].density, null);
+eq('stats: singleton silhouette is 0 by convention', A.clusterStats([1, 5], [1, 2], 2)[0].silhouette, 0);
+eq('stats: tight clusters are denser than an even spread', ss.every(x => x.density > 1), true);
+eq('stats: well separated data scores a high silhouette', ss.every(x => x.silhouette > 0.7), true);
+eq('stats: density is unit-free', (() => {
+  const scaled = sv.map(v => v * 1000);
+  const r2 = A.clusterValues(scaled, 4);
+  const s2 = A.clusterStats(scaled, r2.assign, 4);
+  return s2.every((x, i) => Math.abs(x.density - ss[i].density) < 1e-9);
+})(), true);
+
+const ov = A.overallStats(sv, ss);
+eq('overall: n', ov.n, sv.length);
+near('overall: width', ov.width, 0.97 - 0.16, 1e-12);
+eq('overall: clustering explains most of the spread', ov.explained > 0.98, true);
+eq('overall: silhouette is the n-weighted mean', Math.abs(ov.silhouette -
+  ss.reduce((a, x) => a + x.silhouette * x.n, 0) / sv.length) < 1e-12, true);
+eq('overall: empty input returns null', A.overallStats([], []), null);
+
 // ---- spectral ramp matches the validated values in SPEC.md 5.2
 eq('ramp k=3', A.rampFor(3), ['#7853d5', '#00cd89', '#e54e3f']);
 eq('ramp k=5', A.rampFor(5), ['#7853d5', '#00a0cc', '#00cd89', '#e7c100', '#e54e3f']);


### PR DESCRIPTION
Prototype for you to test — branch is checked out in the working tree, so reload `localhost:8080/structural_tools/clustering/`, press **Load example**, then click a cluster in the legend or the statistics table.

Note this stacks on [#34](https://github.com/magnusfjeldolsen/structural_tools/pull/34), which is still unmerged.

## The distribution tab

Click a cluster — legend, statistics row, or double-click a point — and it opens as a tab. Histogram on top, **every point** as a jittered strip below on the same x axis, one threshold draggable across both. Readout: count and share at-or-below / above, mean of each side, and the threshold's percentile within the band.

## Where the work goes — the measurements changed the design

| work | cost | where | cancellable |
|---|---|---|---|
| threshold count | `O(log n)` binary search | main thread | **never needs to be** |
| rebinning | `O(n)` | main thread | no |
| scatter repaint | `O(n)` canvas arcs | main thread | no |
| **clustering** | **`O(k·n²)`** | **worker** | **yes, by termination** |

**The slider does not need a worker.** On a presorted band the count is a binary search — measured at **0,80 ms on a 20 000-point cluster**, comfortably inside a 60 Hz frame. Putting it behind a worker with a cancellation path would be machinery guarding nothing. Events collapse through `requestAnimationFrame` and only the overlay canvas repaints.

**Panic belongs on the clustering pass**, which genuinely locks a tab. A worker mid-computation can't read its own message queue, so a newer job can't ask it to stop — `panic()` terminates it and respawns, a few ms against the hundreds finishing an unwanted pass would cost. Jobs also carry a generation token so superseded replies are dropped on receipt.

**Verified:** ten k-changes issued in one tick → **18 passes abandoned**, settled on the correct final k, no stale render, no errors.

If `Worker` is unavailable (`file://`, old browsers) the same code runs inline and the badge says so.

## The freeze was mostly rendering, not arithmetic

Both charts are `<canvas>` now — each a static layer plus an overlay — so 50 000 rows draw as 50 000 arcs, not 50 000 DOM nodes. At **50 000 rows**: 142 ms main-thread parse and profile, **53 ms** clustering in the worker, 45–65 ms scatter repaint, tab switch 8 ms once cached. The results table renders the first 500 rows (a 50 000-row DOM table is unreadable and freezes the tab); **copy and download are never capped**.

## Two bugs found while testing in Chrome

- `suggestBins` returned **1** for a 4-point cluster — Freedman–Diaconis is right on shape but degenerate on small n, and it drew as a single slab across the whole panel. Now floored at `min(n, 8)`.
- I deleted the statistics block with an over-wide slice in one of my own patches; caught it, recovered it from HEAD.

## Verification

`node clustering/test.js` — **93 vectors, all pass** (23 new: histogram, prefix sums, upper bound, threshold stats, including empty / single-value / past-both-ends). No console errors across paste, 50 k paste, tab open/close, slider, bins, k bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
