### PR TITLE
docs(clustering): say that the statistics rows are clickable

### DIFF
--- a/clustering/index.html
+++ b/clustering/index.html
@@ -275,6 +275,10 @@
       <button class="pill" id="copyStatsBtn">Copy stats (TSV)</button>
       <span class="muted ml-auto" id="statsSummary"></span>
     </div>
+    <div class="muted mb-2" style="color:#8fa3bd">
+      <span style="color:#38bdf8">›</span> Click any row to analyse that cluster — its histogram, every
+      point in it, and a threshold you can drag to read off how much sits above or below.
+    </div>
     <div class="out" style="max-height:none"><table class="res" id="statsTable"></table></div>
     <div class="muted mt-2 leading-relaxed" id="statsNote"></div>
   </div>


### PR DESCRIPTION
The rows open a cluster's distribution, but nothing on the page said so — the only cue was the cursor changing on hover, which nobody hunts for.

A line above the table now names what a click gets you:

> ` › ` Click any row to analyse that cluster — its histogram, every point in it, and a threshold you can drag to read off how much sits above or below.

Text only, no behaviour change. 93 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)